### PR TITLE
Fix link error (#3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,12 @@ if(MDI)
   include(MDI)
 endif(MDI)
 
+# GPU functionality
+option(GPU "GPU build flag" OFF)
+if(GPU)
+  add_definitions(-DGPU)
+endif(GPU)
+
 # Add tests
 enable_testing()
 add_subdirectory(tests)

--- a/src/SCF/iter.F90
+++ b/src/SCF/iter.F90
@@ -31,7 +31,7 @@
          nbeta_open, npulay, method_indo
       USE reimers_C, only: dd, ff, tot, cc0, aa, dtmp, nb2
       use cosmo_C, only : useps
-#if GPU
+#ifdef GPU
       Use mod_vars_cuda, only: lgpu, real_cuda, prec
       use density_cuda_i
 #endif
@@ -202,12 +202,12 @@
         halfe = (nopen /= nclose .and. Abs(fract - 2.D0) > 1.d-20 .and. Abs(fract) > 1.d-20)
         if (halfe) then
           iopc_calcp = 3            ! DGEMM on CPU
-#if GPU
+#ifdef GPU
           if (lgpu) iopc_calcp = 2  ! DGEMM on GPU
 #endif
         else
           iopc_calcp = 5            ! DSYRK on CPU
-#if GPU
+#ifdef GPU
           if (lgpu) iopc_calcp = 4  ! DSYRK on GPU
 #endif
         end if
@@ -812,7 +812,7 @@
 !                                                                      *
 !***********************************************************************
            if (okpuly .and. makea .and. iredy>1) then
-#if GPU
+#ifdef GPU
               if (lgpu) then
                  call pulay_for_gpu (f, pa, norbs, pold, pold2, pold3, &
                  & jalp, ialp, npulay*mpack, frst, pl)
@@ -820,7 +820,7 @@
 #endif
                  call pulay (f, pa, norbs, pold, pold2, pold3, &
                  & jalp, ialp, npulay*mpack, frst, pl)
-#if GPU
+#ifdef GPU
               end if
 #endif
           end if
@@ -925,7 +925,7 @@
 !                                                                      *
 !***********************************************************************
             if (okpuly .and. makeb .and. iredy>1) then
-#if GPU
+#ifdef GPU
               if (lgpu) then
                  call pulay_for_gpu (fb, pb, norbs, pbold, pbold2, pbold3, &
                  & jbet, ibet, npulay*mpack, bfrst, plb)
@@ -933,7 +933,7 @@
 #endif
                 call pulay (fb, pb, norbs, pbold, pbold2, pbold3, &
                  & jbet, ibet, npulay*mpack, bfrst, plb)
-#if GPU
+#ifdef GPU
               end if
 #endif
           end if

--- a/src/deprecated/pulay_for_gpu.F90
+++ b/src/deprecated/pulay_for_gpu.F90
@@ -18,7 +18,7 @@
                         & lfock, nfock, msize, start, pl) 
       use chanel_C, only : iw
       use molkst_C, only : numcal, keywrd, mpack
-#if GPU
+#ifdef GPU
       Use mult_symm_ab_I 
       Use mod_vars_cuda, only: real_cuda, prec, ngpus
 #endif      
@@ -40,7 +40,7 @@
       double precision, dimension(20) :: coeffs 
       double precision :: const, d, sum 
       logical :: debug  
-#if GPU
+#ifdef GPU
       integer :: igrid, iblock
 #endif        
       double precision, external :: ddot       

--- a/src/matrix/density_for_GPU.F90
+++ b/src/matrix/density_for_GPU.F90
@@ -15,7 +15,7 @@
 ! along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 subroutine density_for_GPU (c, fract, ndubl, nsingl, occ, mpack, norbs, mode, pp, iopc)
-#if GPU
+#ifdef GPU
       Use mod_vars_cuda, only: real_cuda, prec, nthreads_gpu, nblocks_gpu
       Use iso_c_binding    
       Use density_cuda_i
@@ -28,7 +28,7 @@ subroutine density_for_GPU (c, fract, ndubl, nsingl, occ, mpack, norbs, mode, pp
       double precision,allocatable :: xmat(:,:)
       double precision :: c(norbs,norbs), pp(mpack)
       double precision :: cst, sign, fract, frac, occ, sum1, sum2
-#if GPU
+#ifdef GPU
       double precision, allocatable :: pdens(:)
 #endif
       if (ndubl /= 0 .and. nsingl > (norbs/2) .and. mode /= 2) then
@@ -56,7 +56,7 @@ subroutine density_for_GPU (c, fract, ndubl, nsingl, occ, mpack, norbs, mode, pp
       end if
       Select case (iopc)
         case(2)   ! Option to use dgemm from CUBLAS
-#if GPU
+#ifdef GPU
 
           nl21 = Min (norbs, nl2)
           nl11 = Min (norbs, nl1)
@@ -92,7 +92,7 @@ subroutine density_for_GPU (c, fract, ndubl, nsingl, occ, mpack, norbs, mode, pp
 
           deallocate (xmat,stat=i)
         case(4)   ! Option to use dsyrk from CUBLAS 
-#if GPU
+#ifdef GPU
           allocate(xmat(norbs,norbs),stat = i)
           forall (j = 1:norbs, i=1:norbs) xmat(i, j) = 0.d0
           call syrk_cublas ('U','N',norbs,ndubl, &

--- a/src/matrix/diag_for_GPU.F90
+++ b/src/matrix/diag_for_GPU.F90
@@ -18,7 +18,7 @@ subroutine diag_for_GPU (fao, vector, nocc, eig, norbs, mpack)
 #ifdef MKL
     use molkst_C, only: num_threads
 #endif
-#if GPU
+#ifdef GPU
     Use mod_vars_cuda, only: lgpu, prec, ngpus
     Use iso_c_binding
     use call_rot_cuda
@@ -34,7 +34,7 @@ subroutine diag_for_GPU (fao, vector, nocc, eig, norbs, mpack)
     double precision :: bigeps = 1.5d-007
     double precision :: a, alpha, b, beta, d, e, tiny, x
     double precision, allocatable, dimension(:,:)  :: fck
-#if GPU
+#ifdef GPU
     double precision, allocatable, dimension(:,:)  :: ci0,ca0 ! alp,bet
 #endif
     integer :: kk      
@@ -113,7 +113,7 @@ subroutine diag_for_GPU (fao, vector, nocc, eig, norbs, mpack)
       end do
     end do
 ! here, performs matrix multiplications to form FMO
-#if GPU
+#ifdef GPU
     if (lgpu) then
   !  PERFORMS BOTH MULTIPLICATIONS USING CUBLAS	
       if (nocc < nvirt) then
@@ -143,7 +143,7 @@ subroutine diag_for_GPU (fao, vector, nocc, eig, norbs, mpack)
         call dgemm ("T", "N", nvirt, nocc, n, 1.d0, fck, norbs, vector, mdim, &
         & 0.d0, fmo, nvirt)
       end if
-#if GPU
+#ifdef GPU
     end if
 #endif
     i = idamax (nocc*nvirt, fmo, 1)
@@ -154,7 +154,7 @@ subroutine diag_for_GPU (fao, vector, nocc, eig, norbs, mpack)
 !
 !***********************************************************************
     kk = 1
-#if GPU
+#ifdef GPU
     if (lgpu) then
       kk = 2
     end if
@@ -209,7 +209,7 @@ subroutine diag_for_GPU (fao, vector, nocc, eig, norbs, mpack)
 
        case (2)
 
-#if GPU
+#ifdef GPU
          allocate (ci0(n,nocc),ca0(n,nvirt),stat=i)
 
          ci0 = vector(1:n,1:nocc)

--- a/src/matrix/eigenvectors_LAPACK.F90
+++ b/src/matrix/eigenvectors_LAPACK.F90
@@ -16,7 +16,7 @@
 
     Subroutine eigenvectors_LAPACK(eigenvecs, xmat, eigvals, ndim)  
       USE chanel_C, only : iw
-#if GPU
+#ifdef GPU
       Use mod_vars_cuda, only: lgpu, ngpus, prec
 #endif
 #if (MAGMA)
@@ -56,7 +56,7 @@
       call dtpttr( 'u', ndim, xmat, eigenvecs, ndim, i )
     
 #ifdef MKL
-#if GPU
+#ifdef GPU
 if (lgpu .and. (ngpus > 1 .and. ndim > 100)) then
       call mkl_dimatcopy('C', 'T' , ndim, ndim, 1.0d0, eigenvecs, ndim, ndim)
 end if

--- a/src/matrix/mult_symm_AB.F90
+++ b/src/matrix/mult_symm_AB.F90
@@ -19,7 +19,7 @@
 
 !        Use mod_vars_cuda, only: ngpus
         Use iso_c_binding
-#if GPU
+#ifdef GPU
         Use call_gemm_cublas
         Use mamult_cuda_i 
         use common_arrays_C, only : ifact
@@ -27,7 +27,7 @@
         implicit none
         Integer :: iopc,ndim,mdim           
         Integer :: i
-#if GPU
+#ifdef GPU
         integer :: igrid, iblock
         real :: tt      
 #endif
@@ -48,8 +48,8 @@
         
           case (1) ! mamult
             call mamult (a, b, c, ndim, beta)      
+#ifdef GPU
           case (2) ! mamult_gpu
-#if GPU
             igrid = 512 ; iblock = 512 
             tt = 0.0
             call mamult_gpu(a, b, c, ndim, mdim, ifact, beta, igrid, iblock, tt, 0)
@@ -90,7 +90,9 @@
 
             call dtrttp('u', ndim, xc, ndim, c, i )
             
-            deallocate (xa,xb,xc,stat=i)         
+            deallocate (xa,xb,xc,stat=i)
+
+#ifdef GPU
           case (4) ! dgemm_gpu
 
             allocate (xa(ndim,ndim), xb(ndim,ndim), xc(ndim,ndim),stat=i)
@@ -137,6 +139,7 @@
             call dtrttp('u', ndim, xc, ndim, c, i )
             
             deallocate (xa,xb,xc,stat=i) 
+#endif
         end select
                   
         continue

--- a/src/run_mopac.F90
+++ b/src/run_mopac.F90
@@ -54,7 +54,7 @@
 !
       USE reimers_C, only: noh, nvl, cc0, nel, norb, norbl, norbh,&
           nshell, filenm, lenf, evalmo, nbt, multci, occfr, vca, vcb
-#if GPU
+#ifdef GPU
       Use iso_c_binding 
       Use mod_vars_cuda, only: lgpu, ngpus, gpu_id
       Use gpu_info
@@ -70,7 +70,7 @@
       integer :: num_threads
       integer, external :: mkl_get_max_threads
 #endif
-#if GPU
+#ifdef GPU
       logical :: lgpu_ref
       logical(c_bool)    :: hasGpu = .false.
       logical(c_bool)    :: lstat = .false.
@@ -229,7 +229,7 @@
         end if
         call mkl_set_num_threads(num_threads)
 #endif
-#if GPU
+#ifdef GPU
         gpuName(1:6) = '' ; name_size(1:6) = 0 ; totalMem(1:6) = 0 ; clockRate(1:6) = 0
         hasDouble(1:6) = .false. ; gpu_ok(1:6) = .false.
         clockRate(1:6) = 0 ; major(1:6) = 0 ; minor(1:6) = 0; on_off(1:6) = 'OFF'


### PR DESCRIPTION
The link problem described in #3 arises at the line
https://github.com/openmopac/MOPAC/blob/543a4a6ad29ffc24e1e7c48137f4f8260262f4f5/src/matrix/mult_symm_AB.F90#L132

which calls `gemm_cublas` in a region that's not protected by `#if`s.

This pull request 

- changes the `#if`s into `#ifdef`s (`#if`s don't work if the macro is not defined!)
- envelops the offending call in `#ifdef`s

Oddly, I only got the link error in `rpmbuild`; my local CMake build was fine...