### PR TITLE
CMakeLists: fixed default build type, added option for static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,15 +29,31 @@ endif()
 # Follow GNU conventions for installing directories (languages need to be enabled at this stage)
 include(GNUInstallDirs)
 
+# Static or dynamic build
+option(STATIC_BUILD "Build a static executable" OFF)
+if (STATIC_BUILD)
+  message(STATUS "Static executables")
+else()
+  message(STATUS "Shared library and dynamic executables")
+endif()
+
 # Code coverage option
 option(ENABLE_COVERAGE "Code coverage flag" OFF)
 
-# Set a safe default build type
-if(ENABLE_COVERAGE)
-  set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build.")
+# Set a safe default build type if ther is no user input
+if(NOT CMAKE_BUILD_TYPE)
+  if (ENABLE_COVERAGE)
+    set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build." FORCE)
+  else()
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  endif()
 else()
-  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build.")
+# otherwise, check conflict with ENABLE_COVERAGE
+  if(ENABLE_COVERAGE AND NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    message(FATAL_ERROR "Option ENABLE_COVERAGE requires CMAKE_BUILD_TYPE=Debug")
+  endif()
 endif()
+
 message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")
 
 # location for CMake modules
@@ -54,7 +70,15 @@ endif()
 
 
 # Define a common library and executables for MOPAC & PARAM
-add_library(mopac-core SHARED)
+if (STATIC_BUILD)
+  # Static build
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
+  set(CMAKE_EXE_LINKER_FLAGS "-static")
+  add_library(mopac-core STATIC)
+  set(BLA_STATIC ON)
+else()
+  add_library(mopac-core SHARED)
+endif()
 set_target_properties(mopac-core PROPERTIES OUTPUT_NAME "mopac")
 add_executable(mopac)
 add_executable(mopac-param)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-# Using Cmake version 3.11 for better CUDA & Fortran support
-cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+# Using Cmake version 3.13 for target_link_options
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 # Specify project name & programming languages
 project(openmopac VERSION 22.0.0 LANGUAGES Fortran)
@@ -73,8 +73,8 @@ endif()
 if (STATIC_BUILD)
   # Static build
   set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
-  set(CMAKE_EXE_LINKER_FLAGS "-static")
   add_library(mopac-core STATIC)
+  target_link_options(mopac-core PUBLIC "-static")
   set(BLA_STATIC ON)
 else()
   add_library(mopac-core SHARED)
@@ -85,6 +85,11 @@ add_executable(mopac-param)
 add_executable(mopac-makpol)
 target_link_libraries(mopac mopac-core)
 target_link_libraries(mopac-param mopac-core)
+if (STATIC_BUILD)
+  target_link_options(mopac PUBLIC "-static")
+  target_link_options(mopac-param PUBLIC "-static")
+  target_link_options(mopac-makpol PUBLIC "-static")
+endif()
 
 # WinMOPAC build on Windows w/ the Intel Fortran compiler
 option(BUILD_WINMOPAC "Build MOPAC & BZ with QuickWin GUI (ifort required)" OFF)
@@ -102,6 +107,10 @@ if(BUILD_WINMOPAC)
   add_executable(mopac-bz)
   target_compile_options(mopac-bz PRIVATE /libs:qwin)
   target_link_options(mopac-bz PRIVATE /subsystem:windows)
+  if (STATIC_BUILD)
+    target_link_options(mopac-win PUBLIC "-static")
+    target_link_options(mopac-bz PUBLIC "-static")
+  endif()
 endif()
 
 # MOPAC shared library ABI compatibility version


### PR DESCRIPTION
<!-- Describe your PR -->
## Small improvements in CMakeLists
**Issue:** When CMAKE_BUILD_TYPE was not provided by the user (the variable was empty), cmake defaulted to a debug build. As a result, the default compilation run without any options (and that's what most users will do) yields a binary with lower performance.

**Solution:** The default value is set depending on ENABLE_COVERAGE which correctly defaults to OFF. Therefore, in no options are set by user, the build type is set to "Release". Additionally, if both options are set, conflict between CMAKE_BUILD_TYPE=Release and ENABLE_COVERAGE=ON is checked and yields an error.

**Additional feature:** I've added a new option STATIC_BUILD for building a static binaries. The default is OFF, and the script behaves the same as before. The static compilation works well with gfortran/OpenBlas but fails with Intel/MKL.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
