### PR TITLE
Fix Linux installer (missing OpenMP library)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,9 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
     if(INTEL_OMP_LIB STREQUAL "INTEL_OMP_LIB-NOTFOUND")
       message("WARNING: Cannot locate Intel's OpenMP shared library for packaging")
     endif()
-    install(FILES ${INTEL_OMP_LIB} DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT qtifw EXCLUDE_FROM_ALL)
+    # resolve symbolic links
+    get_filename_component(INTEL_OMP_LIB_PATH ${INTEL_OMP_LIB} REALPATH)
+    install(FILES ${INTEL_OMP_LIB_PATH} DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT qtifw EXCLUDE_FROM_ALL)
   endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@ The modern open-source version of the Molecular Orbital PACkage (MOPAC).
 This version contains a CMake build script and compiles a shared library in addition to an executable for integration with other software.
 
 Self-contained installers for Linux, Mac, and Windows are available for each release.
+
+While the installers are meant to be run from a desktop environment by default, they can also be run from a command line without user input.
+On Linux, the basic command-line installation syntax is:
+
+`./mopac-x.y.z-linux.run install --root --accept-licenses --confirm-command --root type_installation_directory_here`
+
+For more information on command-line installation, see the [Qt Installer Framework Documentation](https://doc.qt.io/qtinstallerframework/ifw-cli.html).


### PR DESCRIPTION
<!-- Describe your PR -->
A bug report to openmopac@gmail.com indicated that the Linux installer does not contain the Intel OpenMP library. The likely culprit is a failure to resolve symbolic links to the library.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
