### PR TITLE
Fix ++ behavior in GEO_REF files

### DIFF
--- a/src/input/geo_ref.F90
+++ b/src/input/geo_ref.F90
@@ -259,8 +259,7 @@
           call l_control("GEO_DAT", len_trim("GEO_DAT"), -1)
           call l_control("GEO_REF", len_trim("GEO_REF"), -1)
           line = trim(keywrd)
-          if (index(line, " +") /= 0) i = i - 1
-          if (index(line, "++") /= 0) i = i - 1
+          if (index(line, " +") + index(line, "++") /= 0) i = i - 1
         end if
         if (i == 3) exit
       end do


### PR DESCRIPTION
<!-- Describe your PR -->
Several problems related to GEO_REF were reported in #39. This PR should fix most (or all) of them by correcting a small bug in the parsing of `++` keyword line extenders.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
