### PR TITLE
Remove conventional COSMO size limiter

### DIFF
--- a/src/solvation/cosmo.F90
+++ b/src/solvation/cosmo.F90
@@ -1858,6 +1858,17 @@ subroutine cosini(l_print)
       allocate(cmat((lm61*(lm61 + 1))/2), stat = i)
       j = j + i
       if (j /= 0) then
+        if (l_print) then
+          write(line, '(a, i5, a)')"Data set '"//trim(jobnam)//"' exists, "
+          write(0, '(//10x, a)')trim(line)
+          call mopend(trim(line))
+          write(line, '(a)')"but is too large to run using COSMO."
+          write(0, '(//10x, a)')trim(line)
+          call mopend(trim(line))
+          write(line, '(a, i5, a)')"(This job might run if MOZYME is used.)"
+          write(0, '(/10x, a, //)')trim(line)
+          write(iw, '(/10x, a, //)')trim(line)
+        end if
         call memory_error("COSINI (2) in Cosmo")
         return
       end if

--- a/src/solvation/cosmo.F90
+++ b/src/solvation/cosmo.F90
@@ -1850,21 +1850,6 @@ subroutine cosini(l_print)
       return
     end if
     if (.not. mozyme) then
-      if (lenabc > 22000) then
-        if (l_print) then
-          write(line, '(a, i5, a)')"Data set '"//trim(jobnam)//"' exists, "
-          write(0, '(//10x, a)')trim(line)
-          call mopend(trim(line))
-          write(line, '(a)')"but is too large to run using COSMO."
-          write(0, '(//10x, a)')trim(line)
-          call mopend(trim(line))
-          write(line, '(a, i5, a)')"(This job might run if MOZYME is used.)"
-          write(0, '(/10x, a, //)')trim(line)
-          write(iw, '(/10x, a, //)')trim(line)
-        end if
-        moperr = .true.
-        return
-      end if
       allocate(abcmat(lenabc), xsp(3, lenabc), nset(nppa*numat), bh(lenabc), stat = j)
       allocate(bmat(lm61, lenabc), stat = i)
       j = j + i


### PR DESCRIPTION
<!-- Describe your PR -->
Conventional MOPAC calculations that invoke COSMO have a size limiter that prevents large calculations from being run. The intent was to preclude less informative out-of-memory errors, but this limiter is crude and also prevents users from running large conventional COSMO calculations that have sufficient memory. The clearer error message has been retained, but it only appears when a conventional COSMO calculation actually runs out of memory.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
