### PR TITLE
Reactivate THREADS keyword

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,20 @@ else()
   message(STATUS "AUTO_BLAS=OFF, the user is responsible for linking BLAS & LAPACK libraries (e.g. define compiler link line with MOPAC_LINK)")
 endif()
 
+# Use CMake's system for finding an OpenMP library
+option(ENABLE_OMP "Use OpenMP to enable threading controls" ON)
+if(ENABLE_OMP)
+  find_package(OpenMP)
+  if(OpenMP_Fortran_HAVE_OMPLIB_MODULE)
+    add_definitions(-DOMP_ENABLED)
+
+    # Use OpenMP information provided by CMake's find_package system
+    target_link_libraries(mopac-core PUBLIC ${OpenMP_Fortran_LIBRARIES})
+    target_compile_options(mopac PUBLIC ${OpenMP_Fortran_FLAGS})
+    target_compile_options(mopac-param PUBLIC ${OpenMP_Fortran_FLAGS})
+  endif()
+endif()
+
 # Additional link line
 set(MOPAC_LINK "" CACHE STRING "Additional link line for MOPAC executable.")
 set(MOPAC_LINK_PATH "" CACHE STRING "Path of external dependencies to bundle.")


### PR DESCRIPTION
<!-- Describe your PR -->
As noted in #37, the THREADS keyword was previously deactivated because it relied on MKL-specific functions, and development of MOPAC has moved to more general support of BLAS & LAPACK libraries. However, all known threaded BLAS/LAPACK libraries are based on OpenMP, so we can again support the THREADS keyword through generic OpenMP API calls. The MKL-specific functionality has been hidden behind the `MKL` preprocessor variable for a while, which we are keeping in until the dense linear algebra refactor happens. There is some redundancy between the new `OMP_ENABLED`-filtered code blocks and the deprecated `MKL`-filtered code blocks, but it is practically irrelevant.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
