### PR TITLE
Cleaner tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@
 *.exe
 *.app
 
+# Python intermediates
+__pycache__
+
 # CMake build directories
 build*/
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,18 +16,6 @@
 
 #Basic input/output comparison tests
 
-macro(add_mopac_setup _name _files)
-  # _files is not a list, it's a string... Transform it into a list
-  set(files)
-  string(REPLACE ";" " " _files "${_files}")
-  foreach(_label "${_files}")
-    list(APPEND files ${_label})
-  endforeach()
-  unset(_files)
-
-  add_test(NAME "${_name}" COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/output_compare.py ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/../mopac${CMAKE_EXECUTABLE_SUFFIX} ${_files} SETUP)
-endmacro()
-
 macro(add_mopac_test _name _files)
   # _files is not a list, it's a string... Transform it into a list
   set(files)
@@ -42,8 +30,7 @@ endmacro()
 
 add_subdirectory(keywords)
 
-add_mopac_setup(port "port.mop;port.parameters;try.txt;aa.txt;mol.in")
-
+add_mopac_test(port "port.mop;port.parameters;try.txt;aa.txt;mol.in;SETUP")
 add_mopac_test(crambin "Crambin_1SCF.mop;Crambin_1SCF.den")
 add_mopac_test(mozyme "test_Lewis_for_Proteins.mop")
 add_mopac_test(xeno "Test_XENO.mop")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ macro(add_mopac_test _name _files)
   endforeach()
   unset(_files)
 
-  add_test(NAME "${_name}" COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/output_compare.py ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/../mopac${CMAKE_EXECUTABLE_SUFFIX} ${_files})
+  add_test(NAME "${_name}" COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/run_test.py ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/../mopac${CMAKE_EXECUTABLE_SUFFIX} ${_files})
 endmacro()
 
 add_subdirectory(keywords)

--- a/tests/compare_output.py
+++ b/tests/compare_output.py
@@ -1,13 +1,11 @@
 # Portable Python script for numerical output file comparisons of MOPAC
-# Argument list: <path to testing directory> <path to MOPAC executable> <input file> <data file #1> ... <data file #N>
+# Argument list: <output file #1> <output file #2>
 
 from shutil import copyfile
 from sys import argv
 import subprocess
-import difflib
 import os
 import re
-import math
 import numpy as np
 
 # MOPAC testing has historically been based on checking that the output files corresponding
@@ -55,7 +53,7 @@ def to_float(string):
     except ValueError:
         return False
 
-def parse_mopac_output(path):
+def parse_mopac_out_file(path):
     '''parse a MOPAC output file at a given path into a list of basic elements (strings, numbers, matrices)'''
     parse_line = []
     parse_list = []
@@ -211,7 +209,7 @@ def parse_mopac_output(path):
 
     return parse_line, parse_list
 
-def compare_outputs(out_line, out_list, ref_line, ref_list):
+def compare_mopac_out_file(out_line, out_list, ref_line, ref_list):
     '''Compares the output to the given reference'''
 
     if len(ref_list) != len(out_list):
@@ -265,25 +263,12 @@ def compare_outputs(out_line, out_list, ref_line, ref_list):
                     assert (sval[0] < 1.0 + EIGVEC_THRESHOLD) and (sval[-1] > 1.0 - EIGVEC_THRESHOLD), \
                         f'ERROR: degenerate subspace mismatch on output line {line}, overlap range in [{min(sval)},{max(sval)}]'
 
-# make a local copy of the input & other necessary files
-for file in argv[3:]:
-   copyfile(os.path.join(argv[1],file),file)
+# stub main for command-line comparisons
+if __name__ == "__main__":
 
-# run MOPAC in the local directory
-try:
-    subprocess.run([argv[2],argv[3]], check=True)
-except subprocess.CalledProcessError as err:
-    print("In attempting to run: ", err.cmd)
-    print("stdout: ", err.stdout)
-    print("stderr: ", err.stderr)
+    # parse the 2 output files that we are comparing
+    ref_line, ref_list = parse_mopac_out_file(argv[1])
+    out_line, out_list = parse_mopac_out_file(argv[2])
 
-# only compare ".out" output files that have the same name as ".mop" or ".ent" input files
-out_name = argv[3][:-3]+'out'
-ref_path = os.path.join(argv[1],out_name)
-
-# parse the 2 output files that we are comparing
-ref_line, ref_list = parse_mopac_output(ref_path)
-out_line, out_list = parse_mopac_output(out_name)
-
-# Run the comparison
-compare_outputs(out_line, out_list, ref_line, ref_list)
+    # Run the comparison
+    compare_mopac_out_file(out_line, out_list, ref_line, ref_list)

--- a/tests/compare_output.py
+++ b/tests/compare_output.py
@@ -215,26 +215,26 @@ def compare_mopac_out_file(out_line, out_list, ref_line, ref_list):
     if len(ref_list) != len(out_list):
         print(f'WARNING: output file size mismatch, {len(ref_list)} vs. {len(out_list)}')
 
-    for (line, ref, out) in zip(out_line, ref_list, out_list):
+    for (out_line0, out, ref_line0, ref) in zip(out_line, out_list, ref_line, ref_list):
     #    print(ref, "vs.", out)
         # check that types match
-        assert type(ref) == type(out), f'ERROR: type mismatch between {ref} and {out} on output line {line}'
+        assert type(ref) == type(out), f'ERROR: type mismatch between {ref} on reference line {ref_line0} and {out} on output line {out_line0}'
 
         # compare strings
         if type(ref) is str:
-            assert ref == out, f'ERROR: string mismatch between {ref} and {out} on output line {line}'
+            assert ref == out, f'ERROR: string mismatch between {ref} on reference line {ref_line0} and {out} on output line {out_line0}'
 
         # compare floats
         elif type(ref) is float:
     #        assert abs(ref - out) < NUMERIC_THRESHOLD, f'ERROR: numerical mismatch between {ref} and {out} on output line {line}'
             if abs(ref - out) > NUMERIC_THRESHOLD:
-                print(f'WARNING: numerical mismatch between {ref} and {out} on output line {line}')
+                print(f'WARNING: numerical mismatch between {ref} on reference line {ref_line0} and {out} on output line {out_line0}')
 
         # compare heats of formation
         elif len(ref) == 2:
     #        assert abs(ref[1] - out[1]) < HEAT_THRESHOLD, f'ERROR: numerical heat mismatch between {ref[1]} and {out[1]} on output line {line}'
             if abs(ref[1] - out[1]) > HEAT_THRESHOLD:
-                print(f'WARNING: numerical heat mismatch between {ref[1]} and {out[1]} on output line {line}')
+                print(f'WARNING: numerical heat mismatch between {ref[1]} on reference line {ref_line0} and {out[1]} on output line {out_line0}')
 
         # compare eigenvalues & eigenvectors
         elif len(ref) == 4:
@@ -244,7 +244,7 @@ def compare_mopac_out_file(out_line, out_list, ref_line, ref_list):
             for refv, outv in zip(ref_val,out_val):
     #            assert abs(refv - outv) < NUMERIC_THRESHOLD, f'ERROR: numerical mismatch between {refv} and {outv} on output line {line}'
                 if abs(refv - outv) > NUMERIC_THRESHOLD:
-                    print(f'WARNING: eigenvalue mismatch between {refv} and {outv} on output line {line}')
+                    print(f'WARNING: eigenvalue mismatch between {refv} on reference line {ref_line0} and {outv} on output line {out_line0}')
 
                 # build list of edges denoting degenerate subspaces
                 if ref_begin:
@@ -261,7 +261,7 @@ def compare_mopac_out_file(out_line, out_list, ref_line, ref_list):
     #                print("overlap = ",overlap)
                     sval = np.linalg.svd(overlap, compute_uv=False)
                     assert (sval[0] < 1.0 + EIGVEC_THRESHOLD) and (sval[-1] > 1.0 - EIGVEC_THRESHOLD), \
-                        f'ERROR: degenerate subspace mismatch on output line {line}, overlap range in [{min(sval)},{max(sval)}]'
+                        f'ERROR: degenerate subspace mismatch between reference line {ref_line0} and output line {out_line0}, overlap range in [{min(sval)},{max(sval)}]'
 
 # stub main for command-line comparisons
 if __name__ == "__main__":

--- a/tests/keywords/CMakeLists.txt
+++ b/tests/keywords/CMakeLists.txt
@@ -18,14 +18,14 @@
 
 macro(add_keyword_test _name _files)
  # _files is not a list, it's a string... Transform it into a list
- set(files)
- string(REPLACE ";" " " _files "${_files}")
- foreach(_label "${_files}")
- list(APPEND files ${_label})
- endforeach()
- unset(_files)
+  set(files)
+  string(REPLACE ";" " " _files "${_files}")
+  foreach(_label "${_files}")
+    list(APPEND files ${_label})
+   endforeach()
+  unset(_files)
 
- add_test(NAME "${_name}" COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../output_compare.py ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/../../mopac${CMAKE_EXECUTABLE_SUFFIX} ${_files})
+  add_test(NAME "${_name}" COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../run_test.py ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/../../mopac${CMAKE_EXECUTABLE_SUFFIX} ${_files})
 endmacro()
 
 add_keyword_test(key-ampersand "ampersand.mop")

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -1,0 +1,32 @@
+# Portable Python script to run basic regression tests of MOPAC
+# Argument list: <path to testing directory> <path to MOPAC executable> <input file> <data file #1> ... <data file #N>
+
+from shutil import copyfile
+from sys import argv
+import subprocess
+import os
+
+from compare_output import parse_mopac_out_file, compare_mopac_out_file
+
+# make a local copy of the input & other necessary files
+for file in argv[3:]:
+   copyfile(os.path.join(argv[1],file),file)
+
+# run MOPAC in the local directory
+try:
+    subprocess.run([argv[2],argv[3]], check=True)
+except subprocess.CalledProcessError as err:
+    print("In attempting to run: ", err.cmd)
+    print("stdout: ", err.stdout)
+    print("stderr: ", err.stderr)
+
+# only compare ".out" output files that have the same name as ".mop" or ".ent" input files
+out_name = argv[3][:-3]+'out'
+ref_path = os.path.join(argv[1],out_name)
+
+# parse the 2 output files that we are comparing
+ref_line, ref_list = parse_mopac_out_file(ref_path)
+out_line, out_list = parse_mopac_out_file(out_name)
+
+# Run the comparison
+compare_mopac_out_file(out_line, out_list, ref_line, ref_list)


### PR DESCRIPTION
<!-- Describe your PR -->
The Python testing scripts have been cleaned up to separate the run step from the comparison step, so that the comparison test can be run separately on the command line without re-running the test examples. I've also adjusted the script to print the line on which deviations occur in both the reference and test outputs, which can be different.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
