### PR TITLE
Fix MOZYME density matrix indexing & reference timer in to_screen

### DIFF
--- a/src/output/to_screen.F90
+++ b/src/output/to_screen.F90
@@ -1256,7 +1256,7 @@
         end do
       end do
       bk = seconds(2) - bk
-      if(numat == 0) write(hook,"(a,f12.2)") "DUMMY[1]=",bi ! dummy code to force bi evaluation
+      if(natoms == 0) write(hook,"(a,f12.2)") " DUMMY[1]=",bi ! dummy code to force bi evaluation
       write(hook,"(a,f12.2)")" CPU_TIME:ARBITRARY_UNITS[1]=",time0/bk
     end if
     write(hook,"(a)")" END OF MOPAC FILE"

--- a/src/output/to_screen.F90
+++ b/src/output/to_screen.F90
@@ -67,7 +67,7 @@
 !
   use MOZYME_C, only : ncf, ncocc, noccupied, icocc_dim, cocc_dim, nvirtual, icvir_dim, &
   nncf, iorbs, cocc, icocc, ncvir, nnce, nce, icvir, cvir, tyres, size_mres, &
-  cvir_dim
+  cvir_dim, idiag
 !
   use elemts_C, only : elemnt
 !
@@ -487,10 +487,14 @@
     write(hook,"(a,i"//atoms//",a)")" ATOM_CHARGES[",numat,"]="
     write(hook,"(sp,10f"//fmt9p5//")") (q(i), i=1,numat)
     write(hook,"(a,i"//orbs//",a)")" AO_CHARGES[",norbs,"]="
-    write(hook,"(10f"//fmt9p5//")") (p((i*(i+1))/2), i=1,norbs)
-    if (uhf) then
-      write(hook,"(a,i"//orbs//",a)")" AO_SPINS[",norbs,"]="
-      write(hook,"(10f"//fmt9p5//")") (pa((i*(i+1))/2)-pb((i*(i+1))/2), i=1,norbs)
+    if (mozyme) then
+      write(hook,"(10f"//fmt9p5//")") (p(idiag(i)), i=1,norbs)
+    else
+      write(hook,"(10f"//fmt9p5//")") (p((i*(i+1))/2), i=1,norbs)
+      if (uhf) then
+        write(hook,"(a,i"//orbs//",a)")" AO_SPINS[",norbs,"]="
+        write(hook,"(sp,10f"//fmt9p5//")") (pa((i*(i+1))/2)-pb((i*(i+1))/2), i=1,norbs)
+      end if
     end if
     if (nvar > 0) then
       sum = 0.d0
@@ -1252,6 +1256,7 @@
         end do
       end do
       bk = seconds(2) - bk
+      if(numat == 0) write(hook,"(f12.2)") bi ! dummy code to force bi evaluation
       write(hook,"(a,f12.2)")" CPU_TIME:ARBITRARY_UNITS[1]=",time0/bk
     end if
     write(hook,"(a)")" END OF MOPAC FILE"

--- a/src/output/to_screen.F90
+++ b/src/output/to_screen.F90
@@ -1256,7 +1256,7 @@
         end do
       end do
       bk = seconds(2) - bk
-      if(numat == 0) write(hook,"(f12.2)") bi ! dummy code to force bi evaluation
+      if(numat == 0) write(hook,"(a,f12.2)") "DUMMY[1]=",bi ! dummy code to force bi evaluation
       write(hook,"(a,f12.2)")" CPU_TIME:ARBITRARY_UNITS[1]=",time0/bk
     end if
     write(hook,"(a)")" END OF MOPAC FILE"


### PR DESCRIPTION
<!-- Describe your PR -->
The recently added AO_CHARGES block in the AUX file was not reading the density matrix correctly for MOZYME calculations, which use a compressed sparse matrix storage format rather than a dense matrix format. Also, MOPAC has a reference timer that attempts to produce a CPU-independent benchmark of calculation times, which was not functioning correctly because the dummy reference calculation was being optimized away.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
