### PR TITLE
Fix erratic printing of GRADIENT NORM

### DIFF
--- a/src/output/writmo.F90
+++ b/src/output/writmo.F90
@@ -346,7 +346,7 @@
         end if
       end if
       if (latom == 0) write (iw, '(1X)')
-      if (lprtgra) &
+      if (lprtgra .or. gnorm /= 0.D0) &
         write (iw, '(10X,"GRADIENT NORM           =",F17.5, 10x, "=", 7x, f'//num//'.5, '' PER ATOM'')') &
         gnorm, gnorm/sqrt(1.0*numat)
       if (gnorm > 2.D0 .and. fract > 0.05D0 .and. fract < 1.95D0 .and. &
@@ -1085,7 +1085,7 @@
           vol,  vol*fpc_10*1.d-24
         write(iwrite,*)
       end if
-      if (lprtgra .or. gnorm > 1.D-15 ) write (iwrite, &
+      if (lprtgra .or. gnorm /= 0.D0) write (iwrite, &
         '(  10X, "GRADIENT NORM           =",F17.5, 10x, "=", 7x, f'//num//'.5, " PER ATOM")') gnorm, gnorm/sqrt(1.0*numat)
       if (latom == 0) then
         if (.not.still) then

--- a/src/output/writmo.F90
+++ b/src/output/writmo.F90
@@ -346,7 +346,7 @@
         end if
       end if
       if (latom == 0) write (iw, '(1X)')
-      if (lprtgra .or. gnorm > 1.D-15 ) &
+      if (lprtgra) &
         write (iw, '(10X,"GRADIENT NORM           =",F17.5, 10x, "=", 7x, f'//num//'.5, '' PER ATOM'')') &
         gnorm, gnorm/sqrt(1.0*numat)
       if (gnorm > 2.D0 .and. fract > 0.05D0 .and. fract < 1.95D0 .and. &


### PR DESCRIPTION
<!-- Describe your PR -->
I've identified the cause and fixed #67. As expected, there was logic suppressing a print statement if the printed quantity was smaller than a threshold value, which is sensitive to rounding details that can change between machines. I have removed this instance, and I would ideally like to remove this type of behavior as it is identified. It's a bit presumptuous to assume that a user don't want to know an output when its value is zero, and I just don't want to deal with these complications to the testing process in any other way than removal (unless there is a very good reason for it).

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
