### PR TITLE
Fix AUX bug

### DIFF
--- a/src/output/to_screen.F90
+++ b/src/output/to_screen.F90
@@ -16,7 +16,7 @@
 
   subroutine to_screen(text0)
   use chanel_C, only : iw0
-  use molkst_C, only : keywrd
+  use molkst_C, only : keywrd, keywrd_txt
   implicit none
   character (len=*) :: text0
   character (len=200) :: text
@@ -38,7 +38,7 @@
       call flush (iw0)
     end if
   else
-    if (index(keywrd, " AUX") == 0) return
+    if (index(keywrd, " AUX") == 0 .and. index(keywrd_txt, " AUX") == 0) return
     call current_version(text)
   end if
   end subroutine to_screen


### PR DESCRIPTION
<!-- Describe your PR -->
Fixes #154. There is a barrier to writing to the AUX file if the AUX keyword isn't found, and some code paths are trying to write to the AUX file at moments when the keyword list isn't parsed correctly. I've fixed the barrier for this particular bug, which should prevent this problem from occurring in most cases. Given how complex the I/O of MOPAC is, I can't guarantee that this bug won't pop up under some other conditions.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
