### PR TITLE
Compile with debug symbols when CMAKE_BUILD_TYPE=Debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,10 @@ if (STATIC_BUILD)
   target_link_options(mopac-makpol PUBLIC "-static")
 endif()
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(mopac-core PUBLIC -g)
+endif()
+
 # Add CITATION.cff to source files so that version updates are not ignored
 target_sources(mopac-core PRIVATE CITATION.cff)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,11 @@ if (STATIC_BUILD)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  if(WIN32)
+    target_compile_options(mopac-core PUBLIC /debug:full)
+  else()
     target_compile_options(mopac-core PUBLIC -g)
+  endif()
 endif()
 
 # Add CITATION.cff to source files so that version updates are not ignored


### PR DESCRIPTION
I feel like I must have missed the existing way to do this, but I wanted to step through the code in gdb and couldn't figure out another way to get debug symbols.