### PR TITLE
Fix GEO_REF constraint parsing & + extender bug

### DIFF
--- a/src/input/gettxt.F90
+++ b/src/input/gettxt.F90
@@ -331,7 +331,7 @@
 !
           read (ir, '(A)', end=100, err=100) refkey(3)
           allkey = refkey(3)
-          i = index(allkey, " + ")
+          i = index(allkey, " +")
           if (i /= 0) then
             write(iw,"(a)")" A maximum of three lines of keywords are allowed."
             write(iw,"(a)")" On the third line of keywords is a '+' sign, implying more lines of keywords."
@@ -341,11 +341,12 @@
             return
           end if
           i = index(keywrd(1:len_trim(keywrd)),' +')
-          keywrd(i:i + 1) = " "
+          keywrd(i:i + 1) = "  "
           i = len_trim(keywrd)
           keywrd(i + 2:) = refkey(3)(:1001 - i)
-          i = len_trim(oldkey) + 1
-          oldkey(i:) = trim(refkey(3))
+          i = len_trim(oldkey)
+          oldkey(i:i) = " "
+          oldkey(i+1:) = trim(refkey(3))
           call upcase (keywrd, len_trim(keywrd))
         end if
 !
@@ -413,7 +414,7 @@
       if (numcal > 1) then
         if (index(keywrd,"OLDGEO") /= 0) return ! User forgot to add extra lines for title and comment
         if (aux) keywrd = " AUX"
-        line = "JOB ENDED NORMALLY"       
+        line = "JOB ENDED NORMALLY"
         if (quoted('GEO_DAT"') == 0) then
           line = ' ERROR IN READ OF FIRST THREE LINES' 
         else
@@ -578,17 +579,17 @@
         j = i + k
         if (keywrd(j:j) /= '"') then
           quotation = '"'
-          j = index(keywrd(j:), ' ') + j - 1     
+          j = index(keywrd(j:), ' ') + j - 1
         else
           quotation = ' '
           j = index(keywrd(j + 1:), '"') + j + 1
-          j = index(keywrd(j:), ' ') + j - 1     
-        end if                
+          j = index(keywrd(j:), ' ') + j - 1
+        end if
 !
 ! Copy the keyword that contains quotation marks to keywrd_quoted
 !    
         if (first) then
-          line = trim(keywrd_quoted)        
+          line = trim(keywrd_quoted)
           keywrd_quoted = trim(line)//keywrd(i:i + k -1)//trim(quotation)//old(i + k:j - 1)//trim(quotation)  
           first = .false.
         end if
@@ -646,7 +647,7 @@
             if (keywrd_quoted(j:j) == '"') exit
           end do
         end if
-      end if        
+      end if
       line = keywrd_quoted(i:j)
       end if
     quoted = i

--- a/src/input/gettxt.F90
+++ b/src/input/gettxt.F90
@@ -344,7 +344,7 @@
           keywrd(i:i + 1) = " "
           i = len_trim(keywrd)
           keywrd(i + 2:) = refkey(3)(:1001 - i)
-          i = len_trim(oldkey)
+          i = len_trim(oldkey) + 1
           oldkey(i:) = trim(refkey(3))
           call upcase (keywrd, len_trim(keywrd))
         end if
@@ -629,14 +629,24 @@
 ! for keywords.
 !
     line = " "
-      i = index(keywrd_quoted, trim(key))
-      if (i /= 0) then
- !
-  ! Keyword contains quotation marks, so:
-  !
+    i = index(keywrd_quoted, trim(key))
+    if (i /= 0) then
+!
+! Keyword contains quotation marks, so:
+!
       k = Index (keywrd_quoted(i:), "=") + i
       j = end_of_keyword(keywrd_quoted, len_trim(keywrd_quoted), k) - 2
       i = i + 1 + len_trim(key) 
+      if (trim(key) == "GEO_REF=") then
+        if (index(keywrd_quoted(i:j), '"') /= 0) then
+!
+! Special treatment for "GEO_REF="
+!
+          do j = j, 1, -1
+            if (keywrd_quoted(j:j) == '"') exit
+          end do
+        end if
+      end if        
       line = keywrd_quoted(i:j)
       end if
     quoted = i

--- a/src/input/gettxt.F90
+++ b/src/input/gettxt.F90
@@ -345,8 +345,8 @@
           i = len_trim(keywrd)
           keywrd(i + 2:) = refkey(3)(:1001 - i)
           i = len_trim(oldkey)
-          oldkey(i:i) = " "
-          oldkey(i+1:) = trim(refkey(3))
+          oldkey(i+1:i+1) = " "
+          oldkey(i+2:) = trim(refkey(3))
           call upcase (keywrd, len_trim(keywrd))
         end if
 !

--- a/src/input/wrtkey.F90
+++ b/src/input/wrtkey.F90
@@ -749,14 +749,14 @@ subroutine wrtchk (allkey)
        !
        !    DUMMY IF STATEMENT TO REMOVE AMPERSAND, PLUS SIGNS AND OBSOLETE KEYWORDS, IF PRESENT
        !
-      if (myword(allkey, " SETUP"))       i = 1
-      if (myword(allkey, " &"))           write (iw,'(" *  &         - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
-      if (myword(allkey, " +"))           write (iw,'(" *  +          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
-      if (myword(allkey, " CONTROL"))     i = 2
-      if (myword(allkey, " DIIS"))    write (iw,'(" *  DIIS       - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
-      if (myword(allkey, " NODIIS"))  write (iw,'(" *  NODIIS     - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
-      if (myword(allkey, " ROT"))     write (iw,'(" *  ROT        - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
-      if (myword(allkey, " HEADER") .or. myword(allkey, " USER"))  then
+      if (Index (keywrd, " SETUP"))       i = 1
+      if (Index (keywrd, " &"))           write (iw,'(" *  &          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
+      if (Index (keywrd, " +"))           write (iw,'(" *  +          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
+      if (Index (keywrd, " CONTROL"))     i = 2
+      if (Index (keywrd, " DIIS"))    write (iw,'(" *  DIIS       - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
+      if (Index (keywrd, " NODIIS"))  write (iw,'(" *  NODIIS     - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
+      if (Index (keywrd, " ROT"))     write (iw,'(" *  ROT        - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
+      if (Index (keywrd, " HEADER") .or. (Index (keywrd, " USER"))  then
         write (iw,'(" *  HEADER     - DATA SET IS IN PROTEIN DATA BANK FORMAT")')
         i = index(keywrd, " HEADER")
         keywrd = " ADD-H PDBOUT "//keywrd(:i)

--- a/src/input/wrtkey.F90
+++ b/src/input/wrtkey.F90
@@ -750,9 +750,9 @@ subroutine wrtchk (allkey)
        !    DUMMY IF STATEMENT TO REMOVE AMPERSAND, PLUS SIGNS AND OBSOLETE KEYWORDS, IF PRESENT
        !
       if (myword(allkey, " SETUP"))       i = 1
-      if (myword(allkey, "&"))            i = 2
-      if (myword(allkey, " +"))           i = 3
-      if (myword(allkey, " CONTROL"))     i = 3
+      if (myword(allkey, " &"))           write (iw,'(" *  &         - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
+      if (myword(allkey, " +"))           write (iw,'(" *  +          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
+      if (myword(allkey, " CONTROL"))     i = 2
       if (myword(allkey, " DIIS"))    write (iw,'(" *  DIIS       - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
       if (myword(allkey, " NODIIS"))  write (iw,'(" *  NODIIS     - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
       if (myword(allkey, " ROT"))     write (iw,'(" *  ROT        - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')

--- a/src/input/wrtkey.F90
+++ b/src/input/wrtkey.F90
@@ -749,14 +749,14 @@ subroutine wrtchk (allkey)
        !
        !    DUMMY IF STATEMENT TO REMOVE AMPERSAND, PLUS SIGNS AND OBSOLETE KEYWORDS, IF PRESENT
        !
-      if (Index (keywrd, " SETUP"))       i = 1
-      if (Index (keywrd, " &"))           write (iw,'(" *  &          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
-      if (Index (keywrd, " +"))           write (iw,'(" *  +          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
-      if (Index (keywrd, " CONTROL"))     i = 2
-      if (Index (keywrd, " DIIS"))    write (iw,'(" *  DIIS       - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
-      if (Index (keywrd, " NODIIS"))  write (iw,'(" *  NODIIS     - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
-      if (Index (keywrd, " ROT"))     write (iw,'(" *  ROT        - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
-      if (Index (keywrd, " HEADER") .or. (Index (keywrd, " USER"))  then
+      if (Index (keywrd, " SETUP")    /= 0) i = 1
+      if (Index (keywrd, " &")        /= 0) write (iw,'(" *  &          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
+      if (Index (keywrd, " +")        /= 0) write (iw,'(" *  +          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
+      if (Index (keywrd, " CONTROL")  /= 0) i = 2
+      if (Index (keywrd, " DIIS")     /= 0) write (iw,'(" *  DIIS       - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
+      if (Index (keywrd, " NODIIS")   /= 0) write (iw,'(" *  NODIIS     - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
+      if (Index (keywrd, " ROT")      /= 0) write (iw,'(" *  ROT        - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
+      if (Index (keywrd, " HEADER") /= 0 .or. Index (keywrd, " USER") /= 0)  then
         write (iw,'(" *  HEADER     - DATA SET IS IN PROTEIN DATA BANK FORMAT")')
         i = index(keywrd, " HEADER")
         keywrd = " ADD-H PDBOUT "//keywrd(:i)

--- a/src/input/wrtkey.F90
+++ b/src/input/wrtkey.F90
@@ -749,14 +749,14 @@ subroutine wrtchk (allkey)
        !
        !    DUMMY IF STATEMENT TO REMOVE AMPERSAND, PLUS SIGNS AND OBSOLETE KEYWORDS, IF PRESENT
        !
-      if (Index (keywrd, " SETUP")    /= 0) i = 1
-      if (Index (keywrd, " &")        /= 0) write (iw,'(" *  &          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
-      if (Index (keywrd, " +")        /= 0) write (iw,'(" *  +          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
-      if (Index (keywrd, " CONTROL")  /= 0) i = 2
-      if (Index (keywrd, " DIIS")     /= 0) write (iw,'(" *  DIIS       - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
-      if (Index (keywrd, " NODIIS")   /= 0) write (iw,'(" *  NODIIS     - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
-      if (Index (keywrd, " ROT")      /= 0) write (iw,'(" *  ROT        - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
-      if (Index (keywrd, " HEADER") /= 0 .or. Index (keywrd, " USER") /= 0)  then
+      if (myword(allkey, " SETUP")    ) i = 1
+      if (myword(allkey, " &")        ) write (iw,'(" *  &          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
+      if (myword(allkey, " +")        ) write (iw,'(" *  +          - THIS IS A DEPRECATED KEYWORD, USE "" ++ "" INSTEAD")')
+      if (myword(allkey, " CONTROL")  ) i = 2
+      if (myword(allkey, " DIIS")     ) write (iw,'(" *  DIIS       - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
+      if (myword(allkey, " NODIIS")   ) write (iw,'(" *  NODIIS     - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
+      if (myword(allkey, " ROT")      ) write (iw,'(" *  ROT        - THIS IS AN OBSOLETE KEYWORD, IT WILL BE IGNORED")')
+      if (myword(allkey, " HEADER") .or. myword(allkey, " USER"))  then
         write (iw,'(" *  HEADER     - DATA SET IS IN PROTEIN DATA BANK FORMAT")')
         i = index(keywrd, " HEADER")
         keywrd = " ADD-H PDBOUT "//keywrd(:i)


### PR DESCRIPTION
<!-- Describe your PR -->
Fixes #152. This fix was provided by Jimmy Stewart. When he recently adjusted the input parser for keywords with string arguments, he forgot to treat `GEO_REF` as a special case when harmonic constraints are present. The syntax of constraints is a string (the geometry file) concatenated with a float (the harmonic spring constant), which doesn't occur for any other keyword.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
