### PR TITLE
Temporary PR to assist CCG w/ MOPAC building

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -134,7 +134,7 @@ jobs:
       - name: Build MOPAC with Make
         run: |
           source /opt/intel/oneapi/setvars.sh
-          cmake --build build -- -j$NUM_CORES
+          cmake --build build -- -j$NUM_CORES VERBOSE=1
           ldd -v build/mopac
 
       - name: Test MOPAC with CTest


### PR DESCRIPTION
<!-- Describe your PR -->
CCG is trying to build MOPAC for packaging with MOE, and they are having trouble with linking. I'm temporarily adding in verbose make output so that they can see all the compiler flags and link lines that are triggered by my CI. This PR is not intended for merging.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [ ] Ready for merge
