### PR TITLE
Stress tensor & more consistent gradients in AUX

### DIFF
--- a/src/compfg.F90
+++ b/src/compfg.F90
@@ -457,6 +457,7 @@
         if (moperr) return
         if (times) call timer ('AFTER  DERIV')
         e_disp = store_e_disp
+        if (id == 3 .and. nvar == 3*natoms) call calculate_voigt()
       end if
       if (aider) then
 !

--- a/src/forces/deriv.F90
+++ b/src/forces/deriv.F90
@@ -48,8 +48,8 @@
       double precision :: coord(3*natoms), gold(3*natoms), xparam(3*natoms)
 
 
-      double precision :: grlim, sum, gnorm, step, press, summ, press1, &
-      press2, press3
+      double precision :: grlim, sum, gnorm, step, press
+      double precision, dimension(3,3) :: tderiv
       double precision, external :: dot, volume
       logical :: scf1, halfe, slow, aifrst, debug, precis, intn, geochk, ci, &
         aic, noanci, field, saddle, DH_correction, l_redo_bonds
@@ -258,10 +258,20 @@
             dxyz(j + i + 3) = dxyz(j + i + 3) - tvec(j, 1) * press
           end do
         else if (id == 3) then
-          summ = volume (tvec, 3)
-          press1 = summ / dot (tvec(1, 1), tvec(1, 1), 3) * pressure
-          press2 = summ / dot (tvec(1, 2), tvec(1, 2), 3) * pressure
-          press3 = summ / dot (tvec(1, 3), tvec(1, 3), 3) * pressure
+  ! Transition vector derivatives of pressure times volume
+          press = ((tvec(2, 1)*tvec(3, 2)-tvec(3, 1)*tvec(2, 2))*tvec(1, 3) + &
+                  (tvec(3, 1)*tvec(1, 2)-tvec(1, 1)*tvec(3, 2))*tvec(2, 3) + &
+                  (tvec(1, 1)*tvec(2, 2)-tvec(2, 1)*tvec(1, 2))*tvec(3, 3))
+          tderiv(1, 1) = tvec(2, 2)*tvec(3, 3) - tvec(3, 2)*tvec(2, 3)
+          tderiv(2, 1) = tvec(3, 2)*tvec(1, 3) - tvec(1, 2)*tvec(3, 3)
+          tderiv(3, 1) = tvec(1, 2)*tvec(2, 3) - tvec(2, 2)*tvec(1, 3)
+          tderiv(1, 2) = tvec(3, 1)*tvec(2, 3) - tvec(2, 1)*tvec(3, 3)
+          tderiv(2, 2) = tvec(1, 1)*tvec(3, 3) - tvec(3, 1)*tvec(1, 3)
+          tderiv(3, 2) = tvec(2, 1)*tvec(1, 3) - tvec(1, 1)*tvec(2, 3)
+          tderiv(1, 3) = tvec(2, 1)*tvec(3, 2) - tvec(3, 1)*tvec(2, 2)
+          tderiv(2, 3) = tvec(3, 1)*tvec(1, 2) - tvec(1, 1)*tvec(3, 2)
+          tderiv(3, 3) = tvec(1, 1)*tvec(2, 2) - tvec(2, 1)*tvec(1, 2)
+          tderiv = tderiv*pressure*sign(1.d0, press)
   !
   ! Add in gradient pressure term
   !
@@ -269,30 +279,30 @@
   !
           i = 3*(l1u * (2*l2u+1) * (2*l3u+1) + l2u * (2*l3u+1) + l3u - 1)
           do j = 1, 3
-            dxyz(j + i) = dxyz(j + i) + tvec(j, 1) * press1
-            dxyz(j + i) = dxyz(j + i) + tvec(j, 2) * press2
-            dxyz(j + i) = dxyz(j + i) + tvec(j, 3) * press3
+            dxyz(j + i) = dxyz(j + i) + tderiv(j, 1)
+            dxyz(j + i) = dxyz(j + i) + tderiv(j, 2)
+            dxyz(j + i) = dxyz(j + i) + tderiv(j, 3)
           end do
   !
   !  Cell in 0,0,1 position
   !
           i = 3*(l1u * (2*l2u+1) * (2*l3u+1) + l2u * (2*l3u+1) + l3u)
           do j = 1, 3
-            dxyz(j + i) = dxyz(j + i) - tvec(j, 3) * press3
+            dxyz(j + i) = dxyz(j + i) - tderiv(j, 3)
           end do
   !
   !  Cell in 0,1,0 position
   !
           i = 3*(l1u * (2*l2u+1) * (2*l3u+1) + (l2u+1) * (2*l3u+1) + l3u - 1)
           do j = 1, 3
-            dxyz(j + i) = dxyz(j + i) - tvec(j, 2) * press2
+            dxyz(j + i) = dxyz(j + i) - tderiv(j, 2)
           end do
   !
   !  Cell in 1,0,0 position
   !
           i = 3*((l1u+1) * (2*l2u+1) * (2*l3u+1) + l2u * (2*l3u+1) + l3u - 1)
           do j = 1, 3
-            dxyz(j + i) = dxyz(j + i) - tvec(j, 1) * press1
+            dxyz(j + i) = dxyz(j + i) - tderiv(j, 1)
           end do
         end if
       end if

--- a/src/molkst_C.F90
+++ b/src/molkst_C.F90
@@ -232,7 +232,7 @@ module molkst_C
   &  stress,       & !  Term        Energy due to distortion from reference geometry, used with GEO-REF=
                      !  Units       Kcal/mol
                      !
-  &  press(3),     & ! Type         Pressure on crystal faces
+  &  press(6),     & ! Type         Pressure on crystal faces in Voigt order (xx, yy, zz, yz, xz, xy)
                      ! Definition   Pressure required to stop crystal expanding
                      ! Units        Gigapascals
   &  E_disp,       & ! Dispersion term

--- a/src/molkst_C.F90
+++ b/src/molkst_C.F90
@@ -219,7 +219,7 @@ module molkst_C
   &  cupper,       & !  Upper bound for transition to point charges in solid-state
                      !  Default     cutofp
                      !
-  &  pressure,     & !  Term        Pressure or stress for solid-state and polymer work
+  &  pressure,     & !  Term        Pressure or stress for solid-state and polymer work (sign flipped)
                      !  Definition  Applied isotropic pressure (for solids) or pull (for polymers)
                      !  Units       Pascals (Newtons per square meter) (solids) or Newtons per Mole (polymers)
                      !  Default     0.0
@@ -232,8 +232,11 @@ module molkst_C
   &  stress,       & !  Term        Energy due to distortion from reference geometry, used with GEO-REF=
                      !  Units       Kcal/mol
                      !
-  &  press(6),     & ! Type         Pressure on crystal faces in Voigt order (xx, yy, zz, yz, xz, xy)
+  &  press(3),     & ! Type         Pressure on crystal faces
                      ! Definition   Pressure required to stop crystal expanding
+                     ! Units        Gigapascals
+  &  voigt(6),     & ! Type         Stress tensor in Voigt notation (xx, yy, zz, yz, xz, xy)
+                     ! Definition   Stress tensor is a symmetric 3-by-3 matrix represented by 6 distinct values
                      ! Units        Gigapascals
   &  E_disp,       & ! Dispersion term
   &  E_hb,         & ! Hydrogen-bond term

--- a/src/output/to_screen.F90
+++ b/src/output/to_screen.F90
@@ -61,7 +61,7 @@
 !
   use molkst_C, only : numat, norbs, escf, nelecs, nclose, nopen, verson, &
   method_am1, method_mndo, method_pm3, method_rm1, method_mndod, method_pm6, &
-  method_pm7, nvar, koment, keywrd, zpe, id, density, natoms, formula, press, &
+  method_pm7, nvar, koment, keywrd, zpe, id, density, natoms, formula, press, voigt, &
   uhf, nalpha, nbeta,  gnorm, mozyme, mol_weight, ilim, &
   line, nscf, time0, sz, ss2, no_pKa, title, jobnam, job_no, fract
 !
@@ -436,7 +436,7 @@
         write(hook,"(a,i1,a)")" RESTRAINING_PRESSURE:GIGAPASCALS[3]="
         write(hook,"(3f"//fmt13p5//")")(press(i),i=1,3)
         write(hook,"(a,i1,a)")" VOIGT_STRESS_TENSOR:GIGAPASCALS[6]="
-        write(hook,"(6f"//fmt13p5//")")(press(i),i=1,6)
+        write(hook,"(6f"//fmt13p5//")")(voigt(i),i=1,6)
       end if
     end if
 #ifdef MOPAC_F2003

--- a/src/output/to_screen.F90
+++ b/src/output/to_screen.F90
@@ -361,7 +361,7 @@
 !
     if (abs(escf) > 1.d-30) then
       write(opt_hook,"(a,sp, d"//fmt13p6//",a)")" HEAT_OF_FORM_UPDATED:KCAL/MOL=",escf
-      write(opt_hook,"(a,sp, d"//fmt13p6//",a)")" GRADIENT_UPDATED:KCAL/MOL/ANG=",gnorm
+      write(opt_hook,"(a,sp, d"//fmt13p6//",a)")" GRADIENT_NORM_UPDATED:KCAL/MOL/ANG=",gnorm
 
       write(opt_hook,"(a,i"//paras//",a)")" ATOM_X_UPDATED:ANGSTROMS[",3*numat, "]="
       write(opt_hook,"(3f"//fmt10p4//")") ((coord(j,i),j=1,3), i=1,numat)
@@ -369,6 +369,16 @@
         write(opt_hook,"(a,i1,a)")" TRANS_VECTS_UPDATED:ANGSTROMS[",id*3,"]="
         write(opt_hook,"(3f"//fmt9p4//")")((tvec(j,i),j=1,3),i=1,id)
         if (density > 1.d-1) write(opt_hook,"(a,d"//fmt13p6//",a)")" DENSITY:G/CM^3=",density
+      end if
+      if (id == 3 .and. nvar == 3*natoms) then
+        sum = 0.d0
+        do i = 1, 6
+          if (abs(voigt(i)) > sum) sum = abs(voigt(i))
+        end do
+        if (sum /= 0.d0) then
+          write(hook,"(a,i1,a)")" VOIGT_STRESS_UPDATED:GIGAPASCALS[6]="
+          write(hook,"(6f"//fmt13p5//")")(voigt(i),i=1,6)
+        end if
       end if
       if (nvar > 0) then
         sum = 0.d0
@@ -422,6 +432,16 @@
       write(opt_hook,"(3f"//fmt9p4//")")((tvec(j,i),j=1,3),i=1,id)
       if (density > 1.d-1) write(opt_hook,"(a,d"//fmt13p6//",a)")" DENSITY:G/CM^3=",density
     end if
+    if (id == 3 .and. nvar == 3*natoms) then
+      sum = 0.d0
+      do i = 1, 6
+        if (abs(voigt(i)) > sum) sum = abs(voigt(i))
+      end do
+      if (sum /= 0.d0) then
+        write(hook,"(a,i1,a)")" VOIGT_STRESS_UPDATED:GIGAPASCALS[6]="
+        write(hook,"(6f"//fmt13p5//")")(voigt(i),i=1,6)
+      end if
+    end if
     if (nvar > 0) then
       sum = 0.d0
       do i = 1, nvar
@@ -469,8 +489,14 @@
       end if
     end if
     if (id == 3 .and. nvar == 3*natoms) then
-      write(hook,"(a,i1,a)")" VOIGT_STRESS_TENSOR:GIGAPASCALS[6]="
-      write(hook,"(6f"//fmt13p5//")")(voigt(i),i=1,6)
+      sum = 0.d0
+      do i = 1, 6
+        if (abs(voigt(i)) > sum) sum = abs(voigt(i))
+      end do
+      if (sum /= 0.d0) then
+        write(hook,"(a,i1,a)")" VOIGT_STRESS:GIGAPASCALS[6]="
+        write(hook,"(6f"//fmt13p5//")")(voigt(i),i=1,6)
+      end if
     end if
 #ifdef MOPAC_F2003
     if (.not. ieee_is_nan(dip(4,3))) then
@@ -1159,6 +1185,16 @@
       write(opt_hook,"(a,i1,a)")" TRANS_VECTS_UPDATED:ANGSTROMS[",id*3,"]="
       write(opt_hook,"(3f"//fmt9p4//")")((tvec(j,i),j=1,3),i=1,id)
       if (density > 1.d-1) write(opt_hook,"(a,d"//fmt13p6//",a)")" DENSITY:G/CM^3=",density
+    end if
+    if (id == 3 .and. nvar == 3*natoms) then
+      sum = 0.d0
+      do i = 1, 6
+        if (abs(voigt(i)) > sum) sum = abs(voigt(i))
+      end do
+      if (sum /= 0.d0) then
+        write(hook,"(a,i1,a)")" VOIGT_STRESS_UPDATED:GIGAPASCALS[6]="
+        write(hook,"(6f"//fmt13p5//")")(voigt(i),i=1,6)
+      end if
     end if
     if (nvar > 0) then
       sum = 0.d0

--- a/src/output/to_screen.F90
+++ b/src/output/to_screen.F90
@@ -370,6 +370,19 @@
         write(opt_hook,"(3f"//fmt9p4//")")((tvec(j,i),j=1,3),i=1,id)
         if (density > 1.d-1) write(opt_hook,"(a,d"//fmt13p6//",a)")" DENSITY:G/CM^3=",density
       end if
+      if (nvar > 0) then
+        sum = 0.d0
+        do i = 1, nvar
+          if (abs(grad(i)) > sum) sum = abs(grad(i))
+        end do
+        if (sum > 1.d-4) then
+          write(hook,"(a,i"//paras//",a)")" GRADIENTS_UPDATED:KCAL/MOL/ANGSTROM[",nvar, "]="
+          read(fmt9p4,'(3x,i2)')i
+          j = max(int(log10(sum)),1)
+          write(fmtnnp4,"(i2.2,'.',i2.2)")4 + j + i, i
+          write(hook,"(10f"//fmtnnp4//")") (grad(i), i=1,nvar)
+        end if
+      end if
     end if
     if (opt_hook == 0) call flush (0)
     return
@@ -404,6 +417,24 @@
     end if
     write(opt_hook,"(a,i"//paras//",a)")" ATOM_X_UPDATED:ANGSTROMS[",3*numat, "]="
     write(opt_hook,"(3f"//fmt10p4//")") ((coord(j,i),j=1,3), i=1,numat)
+    if (id > 0) then
+      write(opt_hook,"(a,i1,a)")" TRANS_VECTS_UPDATED:ANGSTROMS[",id*3,"]="
+      write(opt_hook,"(3f"//fmt9p4//")")((tvec(j,i),j=1,3),i=1,id)
+      if (density > 1.d-1) write(opt_hook,"(a,d"//fmt13p6//",a)")" DENSITY:G/CM^3=",density
+    end if
+    if (nvar > 0) then
+      sum = 0.d0
+      do i = 1, nvar
+        if (abs(grad(i)) > sum) sum = abs(grad(i))
+      end do
+      if (sum > 1.d-4) then
+        write(hook,"(a,i"//paras//",a)")" GRADIENTS_UPDATED:KCAL/MOL/ANGSTROM[",nvar, "]="
+        read(fmt9p4,'(3x,i2)')i
+        j = max(int(log10(sum)),1)
+        write(fmtnnp4,"(i2.2,'.',i2.2)")4 + j + i, i
+        write(hook,"(10f"//fmtnnp4//")") (grad(i), i=1,nvar)
+      end if
+    end if
     if (L_MO_s) &
     call print_conventional_M_O_s(opt_hook, compressed, moa_lower, moa_upper, mob_lower, mob_upper, fmt9p4, orbs2)
     if (L_MO_s) &
@@ -435,9 +466,11 @@
       if (Abs(press(1)) > 1.d-20) then
         write(hook,"(a,i1,a)")" RESTRAINING_PRESSURE:GIGAPASCALS[3]="
         write(hook,"(3f"//fmt13p5//")")(press(i),i=1,3)
-        write(hook,"(a,i1,a)")" VOIGT_STRESS_TENSOR:GIGAPASCALS[6]="
-        write(hook,"(6f"//fmt13p5//")")(voigt(i),i=1,6)
       end if
+    end if
+    if (id == 3 .and. nvar == 3*natoms) then
+      write(hook,"(a,i1,a)")" VOIGT_STRESS_TENSOR:GIGAPASCALS[6]="
+      write(hook,"(6f"//fmt13p5//")")(voigt(i),i=1,6)
     end if
 #ifdef MOPAC_F2003
     if (.not. ieee_is_nan(dip(4,3))) then
@@ -1122,6 +1155,24 @@
     write(hook,"(a,sp, d"//fmt13p6//",a)")" HEAT_OF_FORMATION:KCAL/MOL=",escf
     write(hook,"(a,i"//paras//",a)")" ATOM_X_OPT:ANGSTROMS[",3*numat, "]="
     write(hook,"(3f"//fmt10p4//")") ((coord(j,i),j=1,3), i=1,numat)
+    if (id > 0) then
+      write(opt_hook,"(a,i1,a)")" TRANS_VECTS_UPDATED:ANGSTROMS[",id*3,"]="
+      write(opt_hook,"(3f"//fmt9p4//")")((tvec(j,i),j=1,3),i=1,id)
+      if (density > 1.d-1) write(opt_hook,"(a,d"//fmt13p6//",a)")" DENSITY:G/CM^3=",density
+    end if
+    if (nvar > 0) then
+      sum = 0.d0
+      do i = 1, nvar
+        if (abs(grad(i)) > sum) sum = abs(grad(i))
+      end do
+      if (sum > 1.d-4) then
+        write(hook,"(a,i"//paras//",a)")" GRADIENTS_UPDATED:KCAL/MOL/ANGSTROM[",nvar, "]="
+        read(fmt9p4,'(3x,i2)')i
+        j = max(int(log10(sum)),1)
+        write(fmtnnp4,"(i2.2,'.',i2.2)")4 + j + i, i
+        write(hook,"(10f"//fmtnnp4//")") (grad(i), i=1,nvar)
+      end if
+    end if
     if (index(keywrd, " BOND") /= 0)  &
       call write_screen_bonds(compressed, orbs2, hook, fmt9p4)
   else if (mullik) then

--- a/src/output/to_screen.F90
+++ b/src/output/to_screen.F90
@@ -435,6 +435,8 @@
       if (Abs(press(1)) > 1.d-20) then
         write(hook,"(a,i1,a)")" RESTRAINING_PRESSURE:GIGAPASCALS[3]="
         write(hook,"(3f"//fmt13p5//")")(press(i),i=1,3)
+        write(hook,"(a,i1,a)")" VOIGT_STRESS_TENSOR:GIGAPASCALS[6]="
+        write(hook,"(6f"//fmt13p5//")")(press(i),i=1,6)
       end if
     end if
 #ifdef MOPAC_F2003

--- a/src/run_mopac.F90
+++ b/src/run_mopac.F90
@@ -27,7 +27,7 @@
       USE molkst_C, only : gnorm, natoms, numat, nvar, numcal, job_no, nscf, id, &
         escf, iflepo, iscf, keywrd, last, moperr, maxatoms, ncomments, &
         time0, atheat, errtxt, isok, mpack, line, na1, refkey, keywrd_txt, &
-        press, mozyme, step_num, jobnam, nelecs, stress, E_disp, E_hb, E_hh, no_pKa, &
+        press, voigt, mozyme, step_num, jobnam, nelecs, stress, E_disp, E_hb, E_hh, no_pKa, &
         MM_corrections, lxfac, trunc_1, trunc_2, l_normal_html, &
         sparkle, itemp_1, maxtxt, koment, sz, ss2, keywrd_quoted, &
         nl_atoms, use_ref_geo, prt_coords, pdb_label, step, &
@@ -182,6 +182,7 @@
       ediel  = 0.d0
       gnorm  = 0.D0
       press  = 0.d0
+      voigt  = 0.d0
       E_disp = 0.d0
       E_hb   = 0.d0
       E_hh   = 0.d0


### PR DESCRIPTION
<!-- Describe your PR -->
Fixes #131. This PR implements the stress tensor, and it also prints out gradient information more consistently in the AUX file alongside features that also print updated coordinates. Also, this PR fixes a bug in the pressure-dependence of gradients when the translation vectors are non-orthogonal.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [ ] Ready for merge
