### PR TITLE
Fix translation vector summation cutoffs

### DIFF
--- a/src/geometry/CMakeLists.txt
+++ b/src/geometry/CMakeLists.txt
@@ -17,7 +17,7 @@
 #===============================================
 # Create a list of source files (src_list) with the .F90 extension
 set(src_list 
-    gmetry xyzint bangle symtry axis dang dihed volume
+    gmetry xyzint bangle symtry axis dang dihed volume cross
    )
 #-----------------------------------------------
 # Add a list of source files to the target

--- a/src/geometry/cross.F90
+++ b/src/geometry/cross.F90
@@ -1,0 +1,26 @@
+! Molecular Orbital PACkage (MOPAC)
+! Copyright (C) 2021, Virginia Polytechnic Institute and State University
+!
+! MOPAC is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! MOPAC is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+! vector cross product
+subroutine cross(in1, in2, out)
+   implicit none
+   double precision, dimension(3), intent(in) :: in1, in2
+   double precision, dimension(3), intent(out) :: out
+
+   out(1) = in1(2)*in2(3) - in1(3)*in2(2)
+   out(2) = in1(3)*in2(1) - in1(1)*in2(3)
+   out(3) = in1(1)*in2(2) - in1(2)*in2(1)
+end subroutine cross

--- a/src/moldat.F90
+++ b/src/moldat.F90
@@ -1137,8 +1137,16 @@ subroutine setcup
 ! Evaluate maximum lattice summation values that connect the central cell to all atoms
 ! within a radius of cutofp
     l1u = ceiling(sqrt(dot(rvec(:,1), rvec(:,1), 3))*cutofp + lcoord_max(1) - lcoord_min(1))
-    l2u = ceiling(sqrt(dot(rvec(:,2), rvec(:,2), 3))*cutofp + lcoord_max(2) - lcoord_min(2))
-    l3u = ceiling(sqrt(dot(rvec(:,3), rvec(:,3), 3))*cutofp + lcoord_max(3) - lcoord_min(3))
+    if(id > 1) then
+      l2u = ceiling(sqrt(dot(rvec(:,2), rvec(:,2), 3))*cutofp + lcoord_max(2) - lcoord_min(2))
+    else
+      l2u = 0
+    end if
+    if(id == 3) then
+      l3u = ceiling(sqrt(dot(rvec(:,3), rvec(:,3), 3))*cutofp + lcoord_max(3) - lcoord_min(3))
+    else
+      l3u = 0
+    end if
     l123 = (2*l1u + 1)*(2*l2u + 1)*(2*l3u + 1)
     l11 = min(l1u,1)
     l21 = min(l2u,1)


### PR DESCRIPTION
<!-- Describe your PR -->
MOPAC needs to sum over translation vectors when evaluating matrix elements and interactions between atoms in the central unit cell and neighboring unit cells. The cutoffs for this summation were previously determined without checking to see how well atoms were packed into the central unit cell, and poorly packed atoms can invalidate this choice of cutoffs and cause silent errors in periodic calculations. This PR now accounts for the packing of atoms in determining the cutoffs, and also adds a new error if the packing is found to be highly inefficient.

MOPAC does not repack atoms internally, so shifting atomic coordinates by multiples of translation vectors can have an effect on the cost of a MOPAC calculation even if the crystal structures are equivalent. The lowest costs occur for atoms that are tightly packed to fit within a single unit cell of the crystal. There was some consideration to add internal shifting of atoms to pack the central unit cell before starting a periodic calculation, but this would be very difficult to incorporate with MOPAC's existing bookkeeping.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
