### PR TITLE
Fix symmetry operations in BZ

### DIFF
--- a/src/bz/symtrz.F90
+++ b/src/bz/symtrz.F90
@@ -235,7 +235,7 @@ subroutine symtrz (sec_det, nvecs, coord)
         sym_op2: do jj = 1, numat
           do kk = 1, 3
             sum = new_coord(kk, ii) - nijk_CUC(kk,ii) - coord(kk, jj) + nijk_CUC(kk,jj)
-            if (Abs (sum) > 0.2d0) cycle sym_op2
+            if (Abs (sum) > 1d-4) cycle sym_op2
           end do
 !
 !  Atom II has been moved to become atom new(ii) in unit cell incell(1-3,ii)


### PR DESCRIPTION
<!-- Describe your PR -->
This is an attempt to fix #190. Symmetry-equivalent atoms are detected in a loop that throws out atoms that fail a distance check. This distance check is performed in fractional coordinates, and the threshold is too large for unit cells of moderate size. As a result, the test is letting through false positives of symmetry equivalence. The fix should be as simple as tightening this threshold.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
