### PR TITLE
Fix BZ symmetry bug (again)

### DIFF
--- a/src/bz/symtrz.F90
+++ b/src/bz/symtrz.F90
@@ -174,7 +174,7 @@ subroutine symtrz (sec_det, nvecs, coord)
       end if
       sym_op1: do j = 1, numat
         do k = 1, 3
-          if (Abs (new_coord(k, i)  - nijk_CUC(k,i) - coord(k, j) + nijk_CUC(k,j)) > 0.2d0) cycle sym_op1
+          if (Abs (new_coord(k, i)  - nijk_CUC(k,i) - coord(k, j) + nijk_CUC(k,j)) > 1d-4) cycle sym_op1
         end do
         new_coord(:, i) = new_coord(:, i) + nijk_CUC(:,j) - nijk_CUC(:,i)
         itrans(:, i) = itrans(:, i) - nijk_CUC(:,j) + nijk_CUC(:,i)


### PR DESCRIPTION
<!-- Describe your PR -->
This PR is a second attempt to fix the symmetry bug in BZ. I fixed a threshold in one symmetry test without noticing that there was another test with the same problem. Hopefully that is enough to fix the problem, otherwise I'll have to keep tinkering.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [ ] Ready for merge
