### PR TITLE
Fix PDBOUT long comments

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,6 +26,7 @@ env:
 jobs:
   linux-static:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Check number of cores
@@ -67,6 +68,7 @@ jobs:
 
   code-coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Check number of cores
@@ -118,6 +120,7 @@ jobs:
   linux-build:
     # Ubuntu 22+ switched to newer glibc (2.34) that breaks the compatibility library right now
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
 
     steps:
       - name: Check number of cores
@@ -135,7 +138,7 @@ jobs:
       # Set up the QT installer framework
       - uses: jmarrec/setup-qtifw@v1
         with:
-          qtifw-version: '4.x'
+          qtifw-version: '4.6.x'
 
       - name: Cache Intel dependencies
         id: cache-intel
@@ -212,6 +215,7 @@ jobs:
 
   mac-build:
     runs-on: macos-latest
+    timeout-minutes: 30
 
     steps:
       - name: Check number of cores
@@ -229,7 +233,7 @@ jobs:
       # Set up the QT installer framework
       - uses: jmarrec/setup-qtifw@v1
         with:
-          qtifw-version: '4.x'
+          qtifw-version: '4.6.x'
 
       - name: Fix permissions for cache restore
         run: |
@@ -321,6 +325,7 @@ jobs:
   windows-build:
     # NOTE: windows-latest has been switched to Visual Studio 2022, which is not yet supported by Intel development tools
     runs-on: windows-2019
+    timeout-minutes: 30
 
     steps:
       - name: Check number of cores
@@ -339,7 +344,7 @@ jobs:
       # Set up the QT installer framework
       - uses: jmarrec/setup-qtifw@v1
         with:
-          qtifw-version: '4.x'
+          qtifw-version: '4.6.x'
 
       - name: Cache Intel Fortran compiler
         id: cache-intel

--- a/src/chemistry/ligand.F90
+++ b/src/chemistry/ligand.F90
@@ -840,11 +840,12 @@ subroutine ligand (ires, start_res, nfrag)
                 write(line,'(a,i4)') "*REMARK   3 "//het//" = "//trim(het_group)//"   res: ", ires
               end if
               j = len_trim(line)
+              ! hard-coded to allow for only 1 line wrap
               if (j > 80) then
                 j = index(line, "XENO")
-                write(all_comments(ncomments),'(a)') line(1:j +7)
+                write(all_comments(ncomments),'(a)') line(1:76)//">>>"
                 ncomments = ncomments + 1
-                write(all_comments(ncomments),'(a)') "*REMARK   3"//trim(line(j + 7:))
+                write(all_comments(ncomments),'(a)') "*REMARK   3 >>>"//trim(line(77:))
               else
                 write(all_comments(ncomments),'(a)') trim(line)
               end if


### PR DESCRIPTION
<!-- Describe your PR -->
I received a bug report by email where a long comment written by the PDBOUT keyword was causing a string buffer to overflow because the line wrapping was not handled correctly. This PR fixes this bug and also fixes a CI problem caused by a new version of QTIFW that isn't correctly installing on the GHA runners.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
