### PR TITLE
Switch CI to Intel-based Mac runner

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -215,7 +215,8 @@ jobs:
           path: build/mopac-*-linux.*
 
   mac-build:
-    runs-on: macos-latest
+    # macos-latest is now ARM-based, MOPAC is being distributed for Intel-based Macs right now, so using last Intel-based standard runner
+    runs-on: macos-13
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -215,8 +215,8 @@ jobs:
           path: build/mopac-*-linux.*
 
   mac-build:
-    # macos-latest is now ARM-based, MOPAC is being distributed for Intel-based Macs right now, so using last Intel-based standard runner
-    runs-on: macos-13
+    # macos-latest is now ARM-based, MOPAC is being distributed for Intel-based Macs right now, so using Intel-based standard runner from before the recent runner updates
+    runs-on: macos-12
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
<!-- Describe your PR -->
MOPAC is presently being distributed for Intel-based Macs, although it supports ARM-based Macs through conda forge. The default GHA Runners recently switched to ARM processors on Mac, which broke the CI. A bit surprisingly, the Intel Fortran compiler is working just fine on ARM (presumably through the Rosetta-based Intel emulation) and presumably produces an Intel binary that is also running through emulation. While everything seems fine, I'm going to switch to an Intel-based Mac Runner, just to avoid any possible cross-compilation issues. Eventually, the Mac distribution will switch to either ARM-native binaries or universal binaries that run on both ARM and Intel, if that is ever possible with Fortran-based software.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
