### PR TITLE
Remove conditional printing of gradients in AUX file

### DIFF
--- a/src/output/to_screen.F90
+++ b/src/output/to_screen.F90
@@ -385,7 +385,7 @@
         do i = 1, nvar
           if (abs(grad(i)) > sum) sum = abs(grad(i))
         end do
-        if (sum > 1.d-4) then
+        if (sum /= 0.d0) then
           write(hook,"(a,i"//paras//",a)")" GRADIENTS_UPDATED:KCAL/MOL/ANGSTROM[",nvar, "]="
           read(fmt9p4,'(3x,i2)')i
           j = max(int(log10(sum)),1)
@@ -447,7 +447,7 @@
       do i = 1, nvar
         if (abs(grad(i)) > sum) sum = abs(grad(i))
       end do
-      if (sum > 1.d-4) then
+      if (sum /= 0.d0) then
         write(hook,"(a,i"//paras//",a)")" GRADIENTS_UPDATED:KCAL/MOL/ANGSTROM[",nvar, "]="
         read(fmt9p4,'(3x,i2)')i
         j = max(int(log10(sum)),1)
@@ -570,7 +570,7 @@
       do i = 1, nvar
         if (abs(grad(i)) > sum) sum = abs(grad(i))
       end do
-      if (sum > 1.d-4) then
+      if (sum /= 0.d0) then
         write(hook,"(a,i"//paras//",a)")" GRADIENTS:KCAL/MOL/ANGSTROM[",nvar, "]="
         read(fmt9p4,'(3x,i2)')i
         j = max(int(log10(sum)),1)
@@ -1201,7 +1201,7 @@
       do i = 1, nvar
         if (abs(grad(i)) > sum) sum = abs(grad(i))
       end do
-      if (sum > 1.d-4) then
+      if (sum /= 0.d0) then
         write(hook,"(a,i"//paras//",a)")" GRADIENTS_UPDATED:KCAL/MOL/ANGSTROM[",nvar, "]="
         read(fmt9p4,'(3x,i2)')i
         j = max(int(log10(sum)),1)


### PR DESCRIPTION
<!-- Describe your PR -->
Fixes #205. There is still a barrier to printing the gradients, but the output is now only suppressed if all of the gradients are exactly zero. This prevents the printing of uncomputed gradients, which are set to the default value of zero. This is a common logical structure in MOPAC - there aren't convenient logical flags indicating when many properties have been computed, so the existing logic decides if they have been computed based on whether or not they are very small or strictly zero. Certainly logical variables would be preferable, but that isn't the status quo in the code base right now, and it is nontrivial to add them because some properties (e.g. gradients) are computed in multiple locations and under a variety of conditions.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
