### PR TITLE
Further delay of null file handle closing

### DIFF
--- a/src/interface/mopac_api_finalize.F90
+++ b/src/interface/mopac_api_finalize.F90
@@ -53,9 +53,6 @@ contains
     ! record properties
     if (.not. moperr) call mopac_record(properties)
 
-    ! close dummy output file to free up /dev/null
-    close(iw)
-
     ! collect error messages & assign NULL pointers for memory safety
     if (moperr) then
       properties%charge = c_null_ptr
@@ -91,8 +88,12 @@ contains
     ! deallocate memory
     call setup_mopac_arrays(0,0)
     if (mozyme) call delete_MOZYME_arrays()
+
     ! turn use_disk back on
     use_disk = .true.
+
+    ! close dummy output file to free up /dev/null
+    close(iw)
   end subroutine mopac_finalize
 
   subroutine mopac_record(properties)


### PR DESCRIPTION
<!-- Describe your PR -->
On further consideration of #226 and #227, I'm delaying the closing step to the very end of the diskless API operations. There are a lot of stray write statements in MOPAC, and I can see a few more that might trigger the creation of a stray file under certain rare conditions.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
