### PR TITLE
Fix API failure w/ 4 atoms

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,9 +2,9 @@ cff-version: 1.2.0
 message: "If you use this software for a scientific publication, please cite it as below."
 title: MOPAC
 type: software
-version: 23.0.2
+version: 23.0.3
 doi: 10.5281/zenodo.6511958
-date-released: 2024-11-18
+date-released: 2024-12-03
 authors:
   - family-names: Moussa
     given-names: "Jonathan E."

--- a/src/geometry/gmetry.F90
+++ b/src/geometry/gmetry.F90
@@ -109,7 +109,6 @@
           coord(3,3) = coord(3,2)
         end if
 
-        if(size(na) == 4) call exit(1)
         do i = 4, natoms
           if (na(i) == 0) then
             coord(:,i) = geo(:,i)  ! Coordinate is already Cartesian


### PR DESCRIPTION
<!-- Describe your PR -->
Fixes #230. This bug was introduced during the transition between the commercial and open-source versions of MOPAC at commit 93c7072. The most likely explanation is that it was meant to be `exit` to leave a conditional statement (although the statement appeared inside a larger `if` block rather than a `do` loop and would not have worked as such), rather than `call exit(1)`, which is a GNU Fortran extension to terminate the program (that is otherwise not used anywhere else in MOPAC).

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
