### PR TITLE
Fix dielectric energy of zero for systems without valence electrons

### DIFF
--- a/src/compfg.F90
+++ b/src/compfg.F90
@@ -431,7 +431,13 @@
       atheat = atheat + stress
       if (moperr) return
       if (times) call timer ('AFTER  ITER')
-      if(nelecs == 0) elect = 0.D0
+      if (nelecs == 0) then
+        elect = 0.D0
+        f = h
+        if (useps .and. .not. mozyme) then
+          call addfck (f, p)
+        end if
+      end if
       escf = (elect + enuclr)*fpc_9 + atheat
       if (useps .and. mozyme) then
             escf = escf + solv_energy * fpc_9


### PR DESCRIPTION
<!-- Describe your PR -->
Fixes #235, again. In the first fix, I did not realize that a dielectric energy of zero for an ion without valence electrons was erroneous. In COSMO's definition of a dielectric energy, the dielectric energy goes to zero for EPS=1 (i.e. the absence of a dielectric medium). 

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
