### PR TITLE
Ignore single-character labels when printing H bonds

### DIFF
--- a/src/corrections/H_bond_correction_bits.F90
+++ b/src/corrections/H_bond_correction_bits.F90
@@ -356,7 +356,7 @@ subroutine find_H__Y_bonds(acc_a, nacc_a, acc_b, nacc_b, bonding_a_h, nb_a_h, hb
     if (txtatm(D) == " ") write(txtatm(D),'(a,i5,3x,a)')"Atom No.:", D, elemnt(nat(D))
     if (txtatm(H) == " ") write(txtatm(H),'(a,i5,3x,a)')"Atom No.:", H, elemnt(nat(H))
     if (txtatm(A) == " ") write(txtatm(A),'(a,i5,3x,a)')"Atom No.:", A, elemnt(nat(A))
-    if (maxtxt == 0) then
+    if (maxtxt < 2) then
       write(H_txt(P_Hbonds),'(2x,a,f15.3,6x,a,12x,a,10x, f7.2,a)')trim(txtatm(D)), sum1,  &
       trim(txtatm(H)), trim(txtatm(A)), energy, " Kcal/mol"
     else


### PR DESCRIPTION
<!-- Describe your PR -->
This is in response to a small bug reported to and fixed by Jimmy Stewart. Hydrogen bond outputs normally switch from element symbols to atom labels when atom labels are present, but single-character atom labels are also used for Lewis-structure charge assignments in some cases and can disturb the printing of these outputs. This fix preserves the default output scheme in the presence of single-character atom labels.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
