### PR TITLE
Fix LOCATE-TS convergence criterion

### DIFF
--- a/src/reactions/big_swap.F90
+++ b/src/reactions/big_swap.F90
@@ -1465,7 +1465,7 @@ subroutine Locate_TS
     implicit none
     integer, intent (in) :: loop
     logical, intent (in) :: extra_print, l_ts, l_nllsq, l_sigma
-    logical, intent (out) :: converged
+    logical, intent (inout) :: converged
 !
 !  Local
 !
@@ -1473,7 +1473,6 @@ subroutine Locate_TS
     double precision, external :: seconds
     logical :: opend
     character :: num*1
-    converged = .false.
     if (l_ts) then
       line = "TS"
     else if (l_nllsq) then


### PR DESCRIPTION
<!-- Describe your PR -->
I followed-up my examination of #245 with Jimmy to better understand the convergence criterion in the LOCATE-TS feature. I did not realize that `nstep` was being set through module variables for all of the geometry optimizers, and that the convergence criterion was meant to test both the number of steps used by the energy and gradient minimizers. The actual bug was then setting the `converged` flag to `intent(out)` rather than `intent(inout)` in `minimize_gradient`, which did not protect the input value.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
