### PR TITLE
Fix a few API bugs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,9 +2,9 @@ cff-version: 1.2.0
 message: "If you use this software for a scientific publication, please cite it as below."
 title: MOPAC
 type: software
-version: 23.1.0
+version: 23.1.1
 doi: 10.5281/zenodo.6511958
-date-released: 2025-02-06
+date-released: 2025-02-11
 authors:
   - family-names: Moussa
     given-names: "Jonathan E."

--- a/include/mopac_wrapper.F90
+++ b/include/mopac_wrapper.F90
@@ -73,7 +73,7 @@ module mopac_api_f
     double precision, dimension (:), allocatable :: freq
     ! (x,y,z) displacement vectors of normal modes [3*natom_move,3*natom_move], if available
     double precision, dimension (:,:), allocatable :: disp
-    ! bond-order matrix in compressed sparse column (CSC) matrix format
+    ! bond-order matrix in compressed sparse column (CSC) matrix format (1-based indexing)
     ! with insignificant bond orders (<0.01) truncated
     ! diagonal matrix entries are atomic valencies
     ! > first index of each atom in CSC bond-order matrix [natom+1]

--- a/include/mopac_wrapper_internal.F90
+++ b/include/mopac_wrapper_internal.F90
@@ -451,7 +451,7 @@ contains
       call copy_int(properties_f%bond_atom, properties_c%bond_atom, &
                     [properties_f%bond_index(system_c%natom+1)-1])
       do i=1, properties_f%bond_index(system_c%natom+1)-1
-        properties_f%bond_index(i) = properties_f%bond_index(i) + 1
+        properties_f%bond_atom(i) = properties_f%bond_atom(i) + 1
       end do
       call copy_real(properties_f%bond_order, properties_c%bond_order, &
                     [properties_f%bond_index(system_c%natom+1)-1])

--- a/include/mopac_wrapper_internal.F90
+++ b/include/mopac_wrapper_internal.F90
@@ -450,6 +450,9 @@ contains
       end do
       call copy_int(properties_f%bond_atom, properties_c%bond_atom, &
                     [properties_f%bond_index(system_c%natom+1)-1])
+      do i=1, properties_f%bond_index(system_c%natom+1)-1
+        properties_f%bond_index(i) = properties_f%bond_index(i) + 1
+      end do
       call copy_real(properties_f%bond_order, properties_c%bond_order, &
                     [properties_f%bond_index(system_c%natom+1)-1])
       call copy_real(properties_f%lattice_update, properties_c%lattice_update, [3*system_c%nlattice_move])

--- a/src/interface/mopac_api_finalize.F90
+++ b/src/interface/mopac_api_finalize.F90
@@ -223,12 +223,12 @@ contains
               sum = sum + p(k) ** 2
             end do
             if (sum > 0.01d0) then
-              bond_atom(kk) = j
+              bond_atom(kk) = j - 1
               bond_order(kk) = sum
               kk = kk + 1
             end if
           else if (valenc > 0.01d0) then
-            bond_atom(kk) = j
+            bond_atom(kk) = j - 1
             bond_order(kk) = valenc
             kk = kk + 1
           end if
@@ -266,7 +266,7 @@ contains
         kk = bond_index(i) + 1
         do j = 1, i
           if (bondab(ku) > 0.01d0) then
-            bond_atom(kk) = j
+            bond_atom(kk) = j - 1
             bond_order(kk) = bondab(ku)
             kk = kk + 1
           end if
@@ -274,7 +274,7 @@ contains
         end do
         do j = i+1, numat
           if (bondab(kl) > 0.01d0) then
-            bond_atom(kk) = j
+            bond_atom(kk) = j - 1
             bond_order(kk) = bondab(kl)
             kk = kk + 1
           end if

--- a/src/molkst_C.F90
+++ b/src/molkst_C.F90
@@ -257,9 +257,21 @@ module molkst_C
   & formula*100,   & !  Type          Empirical formula
                      !  Definition    Type and number count of each element in the system
                      !  Units         Text
-  & git_hash*40 = 'unknown', & !  Git commit hash string
-  & os*12 = 'unknown', &       !  Operating system name
-  & verson*20 = '23.*.*'       !  Version number for this copy of MOPAC
+#ifdef MOPAC_GIT_HASH
+  & git_hash*40 = MOPAC_GIT_HASH, & !  Git commit hash string
+#else
+  & git_hash*40 = 'unknown', & !  Generic git commit hash string when hash is unavailable
+#endif
+#ifdef MOPAC_OS
+  & os*12 = MOPAC_OS, &       !  Operating system name
+#else
+  & os*12 = 'unknown', &       !  Generic operating system name when OS is unknown
+#endif
+#ifdef MOPAC_VERSION_FULL
+  & verson*20 = MOPAC_VERSION_FULL !  Version number for this copy of MOPAC
+#else
+  & verson*20 = '23.*.*'       !  Generic version number when version is unknown
+#endif
                      !  Pattern      "xx.yy.zz(-pre)"
                      !  Description  major version, minor version, patch version, & pre-release tag
   character ::     &

--- a/src/run_mopac.F90
+++ b/src/run_mopac.F90
@@ -94,15 +94,12 @@
 #endif
 ! parse command-line flags
 #ifdef MOPAC_F2003
-write(*,*) "COMMAND LINE ARGUMENT NUMBER:", command_argument_count()
       do i = 1, command_argument_count()
         call get_command_argument (i, jobnam)
 #else
-  write(*,*) "COMMAND LINE ARGUMENT NUMBER (old):", iargc()
       do i = 1, iargc()
         call getarg (i, jobnam)
 #endif
-write(*,*) "COMMAND LINE ARGUMENTS:", i, jobnam
         if (jobnam == '-V' .OR. jobnam == '--version') then
 #ifdef MOPAC_GIT_HASH
           write(*,"(a)") "MOPAC version "//trim(verson)//" commit "//trim(git_hash)

--- a/src/run_mopac.F90
+++ b/src/run_mopac.F90
@@ -92,24 +92,17 @@
 #ifdef BUILD_MDI
       if (close_mdi) goto 100
 #endif
-! set versioning information
-#ifdef MOPAC_VERSION_FULL
-      verson = MOPAC_VERSION_FULL
-#endif
-#ifdef MOPAC_OS
-      os = MOPAC_OS
-#endif
-#ifdef MOPAC_GIT_HASH
-      git_hash = MOPAC_GIT_HASH
-#endif
 ! parse command-line flags
 #ifdef MOPAC_F2003
+write(*,*) "COMMAND LINE ARGUMENT NUMBER:", command_argument_count()
       do i = 1, command_argument_count()
         call get_command_argument (i, jobnam)
 #else
+  write(*,*) "COMMAND LINE ARGUMENT NUMBER (old):", iargc()
       do i = 1, iargc()
         call getarg (i, jobnam)
 #endif
+write(*,*) "COMMAND LINE ARGUMENTS:", i, jobnam
         if (jobnam == '-V' .OR. jobnam == '--version') then
 #ifdef MOPAC_GIT_HASH
           write(*,"(a)") "MOPAC version "//trim(verson)//" commit "//trim(git_hash)


### PR DESCRIPTION
<!-- Describe your PR -->
While testing mopactools, I uncovered 2 bugs in MOPAC's API. The version info wasn't being set correctly unless a normal MOPAC job was run first, and the bond-order matrix had 1-based indexing for the atoms in the C API (rather than a consistent use of 0-based indexing as advertised). The testing only covered the bond-order matrix in the Fortran API, which is correctly using 1-based indexing.

A patch release is needed before I can release mopactools.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
