### PR TITLE
Fix API bug with no moveable objects

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,9 +2,9 @@ cff-version: 1.2.0
 message: "If you use this software for a scientific publication, please cite it as below."
 title: MOPAC
 type: software
-version: 23.1.1
+version: 23.1.2
 doi: 10.5281/zenodo.6511958
-date-released: 2025-02-11
+date-released: 2025-02-17
 authors:
   - family-names: Moussa
     given-names: "Jonathan E."

--- a/src/interface/mopac_api_operations.F90
+++ b/src/interface/mopac_api_operations.F90
@@ -64,7 +64,7 @@ contains
     type(mopac_properties), intent(out) :: properties
 
     keywrd = " 1SCF PULAY BONDS"
-    if (system%natom_move + system%nlattice_move > 0) trim(keywrd) // " GRADIENTS"
+    if (system%natom_move + system%nlattice_move > 0) keywrd = trim(keywrd) // " GRADIENTS"
     call mopac_initialize(system)
     if (.not. moperr) call mopac_load(state)
     ! call computational routine for SCF calculations
@@ -129,7 +129,7 @@ contains
     type(mopac_properties), intent(out) :: properties
 
     keywrd = " MOZYME 1SCF ALLBONDS"
-    if (system%natom_move + system%nlattice_move > 0) trim(keywrd) // " GRADIENTS"
+    if (system%natom_move + system%nlattice_move > 0) keywrd = trim(keywrd) // " GRADIENTS"
     call mopac_initialize(system)
     if (.not. moperr) call mozyme_load(state)
     ! call computational routine for SCF calculations

--- a/src/interface/mopac_api_operations.F90
+++ b/src/interface/mopac_api_operations.F90
@@ -63,7 +63,8 @@ contains
     type(mopac_state), intent(inout) :: state
     type(mopac_properties), intent(out) :: properties
 
-    keywrd = " 1SCF PULAY GRADIENTS BONDS"
+    keywrd = " 1SCF PULAY BONDS"
+    if (system%natom_move + syste%nlattice_move >= 0) trim(keywrd) // " GRADIENTS"
     call mopac_initialize(system)
     if (.not. moperr) call mopac_load(state)
     ! call computational routine for SCF calculations
@@ -127,7 +128,8 @@ contains
     type(mozyme_state), intent(inout) :: state
     type(mopac_properties), intent(out) :: properties
 
-    keywrd = " MOZYME 1SCF GRADIENTS ALLBONDS"
+    keywrd = " MOZYME 1SCF ALLBONDS"
+    if (system%natom_move + syste%nlattice_move >= 0) trim(keywrd) // " GRADIENTS"
     call mopac_initialize(system)
     if (.not. moperr) call mozyme_load(state)
     ! call computational routine for SCF calculations

--- a/src/interface/mopac_api_operations.F90
+++ b/src/interface/mopac_api_operations.F90
@@ -64,7 +64,7 @@ contains
     type(mopac_properties), intent(out) :: properties
 
     keywrd = " 1SCF PULAY BONDS"
-    if (system%natom_move + syste%nlattice_move >= 0) trim(keywrd) // " GRADIENTS"
+    if (system%natom_move + system%nlattice_move > 0) trim(keywrd) // " GRADIENTS"
     call mopac_initialize(system)
     if (.not. moperr) call mopac_load(state)
     ! call computational routine for SCF calculations
@@ -129,7 +129,7 @@ contains
     type(mopac_properties), intent(out) :: properties
 
     keywrd = " MOZYME 1SCF ALLBONDS"
-    if (system%natom_move + syste%nlattice_move >= 0) trim(keywrd) // " GRADIENTS"
+    if (system%natom_move + system%nlattice_move > 0) trim(keywrd) // " GRADIENTS"
     call mopac_initialize(system)
     if (.not. moperr) call mozyme_load(state)
     ! call computational routine for SCF calculations


### PR DESCRIPTION
<!-- Describe your PR -->
This fixes another small API bug that was found while testing mopactools. SCF calculations fail if there are no moveable atoms or lattice vectors because the `GRADIENTS` keyword expects that a gradient needs to be calculated and flags an error otherwise. Now the `GRADIENTS` keyword is only being used by the API when it is needed.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
