### PR TITLE
COSMO memory reduction

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -149,8 +149,12 @@ Michael Coolidge
    [`DOI:10.1002/jcc.540120807 <https://doi.org/10.1002/jcc.540120807>`_]
 
 Andreas Klamt
-   implementation of the COSMO solvation model
+   reference implementation of the COSMO solvation model
    [`DOI:10.1039/P29930000799 <https://doi.org/10.1039/P29930000799>`_]
+
+Andrey Bliznyuk
+   fast implementation of the COSMO solvation model
+   [`DOI:10.1021/j100039a044 <https://doi.org/10.1021/j100039a044>`_]
 
 Anna Stewart
    copyediting of MOPAC documentation

--- a/src/meci/ijkl.F90
+++ b/src/meci/ijkl.F90
@@ -163,7 +163,7 @@
             end if
           end do
         end do
-        call ciint (cij, wcij)
+        wcij = 0.0d0 ! stub for removed ciint subroutine, this is the only thing it actually did
         do l = 1, i
           ipq = 0
           do ii = 1, numat

--- a/src/setup_mopac_arrays.F90
+++ b/src/setup_mopac_arrays.F90
@@ -53,9 +53,9 @@
   use drc_C, only: vref, vref0, allxyz, allvel, xyz3, vel3, allgeo, geo3, parref
 !
   use cosmo_C, only : ipiden, idenat, gden, qdenet, &
-  phinet, qscnet, qscat, bmat, abcmat, srad, iatsp, &
-  nn, cosurf, xsp, nset, bh, qden, nsetf, isude, sude, &
-  arat, amat, cmat
+  phinet, qscnet, qscat, bmat, srad, iatsp, &
+  nn, cosurf, nset, qden, nsetf, isude, sude, &
+  arat, amat
 !
   use esp_C, only : cen, ex, iam, cc, &
       & cespm, espi, potpt, es, rnai, rnai2, pf0, pf1, pf2, &
@@ -194,7 +194,6 @@
     if (allocated(f)) call fock2(f, f, f, w, w, w, numat, nfirst, nlast, mode)
     if (allocated(a2))         deallocate(a2, stat = i)
     if (allocated(ab))         deallocate(ab, stat = i)
-    if (allocated(abcmat))     deallocate (abcmat, stat = i)
     if (allocated(aicorr))     deallocate (aicorr, stat = i)
     if (allocated(aidref))     deallocate(aidref, stat = i)
     if (allocated(al))         deallocate(al, stat = i)
@@ -206,7 +205,6 @@
     if (allocated(atmass))     deallocate (atmass, stat = i)
     if (allocated(b))          deallocate(b, stat = i)
     if (allocated(b_esp))      deallocate(b_esp, stat = i)
-    if (allocated(bh))         deallocate (bh, stat = i)
     if (allocated(bmat))       deallocate (bmat, stat = i)
     if (allocated(c))          deallocate (c, stat = i)
     if (allocated(cb))         deallocate (cb, stat = i)
@@ -218,7 +216,6 @@
     if (allocated(cespm))      deallocate(cespm, stat = i)
     if (allocated(cespm2))     deallocate(cespm2, stat = i)
     if (allocated(cespml))     deallocate(cespml, stat = i)
-    if (allocated(cmat))       deallocate (cmat, stat = i)
     if (allocated(cnorml))     deallocate(cnorml, stat = i)
     if (allocated(co))         deallocate(co, stat = i)
     if (allocated(coord))      deallocate (coord, stat = i)
@@ -363,7 +360,6 @@
     if (allocated(work2))      deallocate(work2, stat = i)
     if (allocated(xparam))     deallocate (xparam, stat = i)
     if (allocated(xparef))     deallocate (xparef, stat = i)
-    if (allocated(xsp))        deallocate (xsp, stat = i)
     if (allocated(xyz3))       deallocate (xyz3, stat = i)
     if (allocated(occa))       deallocate(occa, stat = i)
     if (allocated(microa))     deallocate(microa, stat = i)

--- a/src/solvation/README.md
+++ b/src/solvation/README.md
@@ -1,4 +1,5 @@
 # COSMO solvation model
 
-This directory contains MOPAC's implementation of the COSMO solvation model,
-which was developed and written by Andreas Klamt.
+This directory contains MOPAC's two implementations of the COSMO solvation model.
+The original, refrence implementation was developed and written by Andreas Klamt.
+The fast implementation, which includes an implementation of the fast multipole method, was written by Andrey Bliznyuk.

--- a/src/solvation/cosmo.F90
+++ b/src/solvation/cosmo.F90
@@ -187,28 +187,6 @@ subroutine ansude (ra, rb, d, rs, ara, arb, aar, abr, arad, arbd, rinc)
     arad = pi * ra * (sad*za + sa*zad + 2.d0*ra*cad)
     arbd = pi * rb * (sbd*zb + sb*zbd + 2.d0*rb*cbd)
 end subroutine ansude
-subroutine ciint (c34, pq34)
-    use molkst_C, only : lm61
-    use cosmo_C, only : nps, cmat
-    implicit none
-    double precision, dimension (lm61), intent (in) :: c34
-    double precision, dimension (lm61), intent (inout) :: pq34
-    integer :: i, i0, j
-    i0 = 0
-    do i = 1, lm61
-      pq34(i) = 0.d0
-    end do
-    if (nps < 0) return
-    do i = 1, lm61
-      do j = 1, i - 1
-        i0 = i0 + 1
-        pq34(j) = pq34(j) + cmat(i0) * c34(i)
-        pq34(i) = pq34(i) + cmat(i0) * c34(j)
-      end do
-      i0 = i0 + 1
-      pq34(i) = pq34(i) + cmat(i0) * c34(i)
-    end do
-end subroutine ciint
 subroutine coscav
    !***********************************************************************
    !
@@ -1749,7 +1727,7 @@ end subroutine surclo
 subroutine cosini(l_print)
     use cosmo_C, only : n0, ioldcv, fnsq, nps, rsolv, nspa, disex2, &
     dirsm, dirvec, srad, ipiden, gden, idenat, qdenet, amat, &
-    cmat, lenabc, arat, sude, isude, bh, qden, nar_csm, nsetf, phinet, &
+    lenabc, arat, sude, isude, bh, qden, nar_csm, nsetf, phinet, &
     qscnet, bmat, nset, xsp, abcmat, iatsp, nn, qscat, cosurf, nppa, &
     ffact, fepsi, nden
     use common_arrays_C, only : nat, nfirst, nlast
@@ -1799,7 +1777,6 @@ subroutine cosini(l_print)
     if (allocated(qscnet)) deallocate (qscnet)
     if (allocated(abcmat)) deallocate (abcmat)
     if (allocated(bmat))   deallocate (bmat)
-    if (allocated(cmat))   deallocate (cmat)
     if (allocated(qscat))  deallocate (qscat)
     if (allocated(srad))   deallocate (srad)
     if (allocated(iatsp))  deallocate (iatsp)
@@ -1838,8 +1815,6 @@ subroutine cosini(l_print)
       j = j + i
       allocate(amat((lenabc*(lenabc + 1))/2), stat = i)
       j = j + i
-      allocate(cmat((lm61*(lm61 + 1))/2), stat = i)
-      j = j + i
       if (j /= 0) then
         if (l_print) then
           write(line, '(a, i5, a)')"Data set '"//trim(jobnam)//"' exists, "
@@ -1855,7 +1830,6 @@ subroutine cosini(l_print)
         call memory_error("COSINI (2) in Cosmo")
         return
       end if
-      cmat = 0.d0
     end if
     call extvdw (usevdw, rvdw)
     if (moperr) return

--- a/src/solvation/cosmo.F90
+++ b/src/solvation/cosmo.F90
@@ -1727,8 +1727,8 @@ end subroutine surclo
 subroutine cosini(l_print)
     use cosmo_C, only : n0, ioldcv, fnsq, nps, rsolv, nspa, disex2, &
     dirsm, dirvec, srad, ipiden, gden, idenat, qdenet, amat, &
-    lenabc, arat, sude, isude, bh, qden, nar_csm, nsetf, phinet, &
-    qscnet, bmat, nset, xsp, abcmat, iatsp, nn, qscat, cosurf, nppa, &
+    lenabc, arat, sude, isude, qden, nar_csm, nsetf, phinet, &
+    qscnet, bmat, nset, iatsp, nn, qscat, cosurf, nppa, &
     ffact, fepsi, nden
     use common_arrays_C, only : nat, nfirst, nlast
     use molkst_C, only : numat, keywrd, moperr, lm61, mozyme, line, jobnam
@@ -1775,7 +1775,6 @@ subroutine cosini(l_print)
     if (allocated(qdenet)) deallocate (qdenet)
     if (allocated(phinet)) deallocate (phinet)
     if (allocated(qscnet)) deallocate (qscnet)
-    if (allocated(abcmat)) deallocate (abcmat)
     if (allocated(bmat))   deallocate (bmat)
     if (allocated(qscat))  deallocate (qscat)
     if (allocated(srad))   deallocate (srad)
@@ -1783,9 +1782,7 @@ subroutine cosini(l_print)
     if (allocated(nar_csm))deallocate (nar_csm)
     if (allocated(nn))     deallocate (nn)
     if (allocated(cosurf)) deallocate (cosurf)
-    if (allocated(xsp))    deallocate (xsp)
     if (allocated(nset))   deallocate (nset)
-    if (allocated(bh))     deallocate (bh)
     if (allocated(qden))   deallocate (qden)
     if (allocated(nar_csm))    deallocate (nar_csm)
     if (allocated(nsetf))  deallocate (nsetf)
@@ -1810,7 +1807,7 @@ subroutine cosini(l_print)
       return
     end if
     if (.not. mozyme) then
-      allocate(abcmat(lenabc), xsp(3, lenabc), nset(nppa*numat), bh(lenabc), stat = j)
+      allocate(nset(nppa*numat), stat = j)
       allocate(bmat(lm61, lenabc), stat = i)
       j = j + i
       allocate(amat((lenabc*(lenabc + 1))/2), stat = i)

--- a/src/solvation/cosmo_C.F90
+++ b/src/solvation/cosmo_C.F90
@@ -43,7 +43,6 @@ module cosmo_C
     cosvol,      & ! Molecular volume, in cubic Angstroms
                    !
     cif1, cif2,  & !
-    cdiagi,      &
    fnsq, rsolv
   double precision :: ffact = 0.d0
   double precision, dimension(:), allocatable :: diagsl
@@ -55,17 +54,12 @@ module cosmo_C
   & qscat,   & !
   & arat,    & !
   & srad,    & !
-  & abcmat,  & !
-  & qden,    & !
-  & bh,      & !
-  & cdiag
+  & qden
   double precision, dimension(:,:), allocatable :: &
   & bmat,    & !
   & phinet,  & !
   & qscnet,  & !
   & qdenet,  & !
   & cosurf,  & !
-  & sude,    & !
-  & xsp,     & !
-  & cxy
+  & sude
 end module cosmo_C

--- a/src/solvation/cosmo_C.F90
+++ b/src/solvation/cosmo_C.F90
@@ -51,7 +51,6 @@ module cosmo_C
   double precision, dimension(4,1082) :: dirsm, dirvec
   double precision, dimension(:), allocatable :: &
   & amat,    & !
-  & cmat,    & !
   & gden,    & !
   & qscat,   & !
   & arat,    & !


### PR DESCRIPTION
<!-- Describe your PR -->
Fixes #269, or at least increases the maximum system size that can be calculated with available memory resources.

The reference implementation of COSMO had some unused arrays, including one (`cmat`) that was large enough to impact MOPAC's overall memory footprint in a significant way under some circumstances. I've cleaned out these unused arrays, and also updated the authorship information about COSMO after noticing that the fast version seems to be based on other work (I don't know the full history, so Klamt or others might have had some involvement in the fast COSMO implementation as well).

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
