### PR TITLE
Update linux GHA runner versions (test)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   linux-static:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
@@ -74,7 +74,7 @@ jobs:
           path: build/tests
 
   code-coverage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
@@ -134,7 +134,7 @@ jobs:
 
   linux-build:
     # Ubuntu 22+ switched to newer glibc (2.34) that breaks the compatibility library right now
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -41,6 +41,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install OpenBLAS with Ubuntu package manager
+        run: sudo apt-get install libopenblas-dev
+
       - name: Install dependencies with PyPI
         run: pip install numpy
 
@@ -92,6 +95,9 @@ jobs:
 
       - name: Install lcov with Ubuntu package manager
         run: sudo apt-get install lcov
+
+      - name: Install OpenBLAS with Ubuntu package manager
+        run: sudo apt-get install libopenblas-dev
 
       - name: Install dependencies with PyPI
         run: pip install numpy


### PR DESCRIPTION
<!-- Describe your PR -->
This is a test PR for updating the Linux GHA runner versions. The Linux CI has been broken since the older Ubuntu runner image was retired about a month ago. I was using the older image because the `glibc` compatibility layer that MOPAC was using to support older systems had stopped working on newer images. I need to figure out an alternative compatibility solution such as locally building an older version of `glibc`, or consider abandoning old `glibc` support, which is highly undesirable.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [ ] Ready for merge
