### PR TITLE
Remove zero-electron barrier for gradients

### DIFF
--- a/src/compfg.F90
+++ b/src/compfg.F90
@@ -457,7 +457,7 @@
       if (lgrad) then
         store_e_disp = e_disp
         if (times) call timer ('Before DERIV')
-        if (nelecs > 0) call deriv (geo, grad)
+        call deriv (geo, grad)
         if (moperr) return
         if (times) call timer ('AFTER  DERIV')
         e_disp = store_e_disp


### PR DESCRIPTION
<!-- Describe your PR -->
Fixes #273. There have been other fixes to the zero-electron case in the past, including some added initialization steps, and nothing about the gradients appears to require further initialization beyond that.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
