### PR TITLE
Remove last defunct references to Java & JMol

### DIFF
--- a/src/output/pdbout.F90
+++ b/src/output/pdbout.F90
@@ -313,7 +313,7 @@ subroutine pdbout (mode1)
     write(iprt,"(/a)") "$(document).ready(function() {Info = {"
     write(iprt,"(10x,a)") "width: 1500,", "height: 1000,", "color: ""0xB0B0B0"",", &
     "disableInitialConsole: true, ", "addSelectionOptions: false,", "j2sPath: ""../jsmol/j2s"",", &
-    "jarPath: ""../jsmol/java"",", "use: ""HTML5"", script: ", " "
+    "use: ""HTML5"", script: ", " "
     write(iprt,"(a)")"// Data set to be loaded", " "
     if (index(keywrd, " GRAPHF") /= 0) then
       line = input_fn(:len_trim(input_fn) - 4)//"mgf"

--- a/src/reactions/pathk.F90
+++ b/src/reactions/pathk.F90
@@ -548,7 +548,6 @@
     write(iprt,"(a)")""
     write(iprt,"(a)")"  Jmol.Info.j2sPath = ""../jsmol/j2s"""
     write(iprt,"(a)")"  "
-    write(iprt,"(a)")" jmolInitialize(""java"",""JmolAppletSigned0.jar"")"
     write(iprt,"(a)")" jmolSetAppletColor(""lightblue"");"
     write(iprt,"(a)")" jmolApplet(600, ""set antialiasDisplay;set loadStructCallback 'plotEnergies';"// &
       "set animFrameCallback 'doHighlight'; load "" + modelFile);"


### PR DESCRIPTION
<!-- Describe your PR -->
MOPAC uses JSMol for a variety of browser-compatible visualization. For web security reasons, the Javascript-based JSMol is now completely separated from the Java-based JMol, which can no longer be accessed from browsers. I don't fully understand the history, but there are some vestigial references to JMol in MOPAC that do not appear to do anything in tests and can be safely removed.

Many of the examples on the MOPAC website have these vestigial JMol references, which I will attempt to clean up during the upcoming migration. I probably won't change the references themselves, since they don't do anything, but I will be consolidating the local JSMol copies to a single instance of the recommended minimal distribution that does not contain any Java.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
