### PR TITLE
API crash fix for SCF calculations

### DIFF
--- a/src/interface/mopac_api_finalize.F90
+++ b/src/interface/mopac_api_finalize.F90
@@ -124,7 +124,7 @@ contains
     properties%stress = voigt
     natom_move = nvar/3
     nlattice_move = 0
-    do i=nvar/3-id, nvar/3
+    do i=nvar/3-id+1, nvar/3
       if (nat(loc(1,3*i)) == 107) then
         natom_move = natom_move - 1
         nlattice_move = nlattice_move + 1


### PR DESCRIPTION
<!-- Describe your PR -->
While using the API for development of other features, I noticed some intermittent crashing for SCF calculations. I tracked it down to a post-processing step with an array bound mistake that causes an out of bounds when a molecule has no optimized coordinates. This fixes the bug and resolves the observed crashing.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
