### PR TITLE
Fixed pruning mozyme bond order matrix in subroutine mopac_record - solves an array overflow

### DIFF
--- a/src/interface/mopac_api_finalize.F90
+++ b/src/interface/mopac_api_finalize.F90
@@ -214,7 +214,7 @@ contains
             valenc = valenc + 2.d0 * p(kk)
           end do
         end if
-        if (valenc > 0.01d0) then 
+        if (valenc > 0.01d0) then
             kk = bond_index(i) + 1
             bond_atom(kk) = j - 1
             bond_order(kk) = valenc

--- a/src/interface/mopac_api_finalize.F90
+++ b/src/interface/mopac_api_finalize.F90
@@ -214,7 +214,12 @@ contains
             valenc = valenc + 2.d0 * p(kk)
           end do
         end if
-        kk = bond_index(i) + 1
+        if (valenc > 0.01d0) then 
+            kk = bond_index(i) + 1
+            bond_atom(kk) = j - 1
+            bond_order(kk) = valenc
+            kk = kk + 1
+        end if
         do j = 1, numat
           jo = iorbs(j)
           if (i /= j .and. ijbo (i, j) >= 0) then
@@ -229,10 +234,6 @@ contains
               bond_order(kk) = sum
               kk = kk + 1
             end if
-          else if (valenc > 0.01d0) then
-            bond_atom(kk) = j - 1
-            bond_order(kk) = valenc
-            kk = kk + 1
           end if
         end do
       end do


### PR DESCRIPTION
The code was writing beyond the end of the `bond_order` array in the mozyme part of the mopac_record routine. This is caused by a mismatch between the 1st pass and 2nd pass loops. I suppose the 1st pass is correct, while the 2nd pass was writing the (i|i) term multiple times as it was in the loop over j. I reworked the 2nd pass loop to match pass 1, and it solved the issue.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [x] Ready for merge
