### PR TITLE
Fix GHA on Windows

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -344,9 +344,6 @@ jobs:
 
   windows-build:
     runs-on: windows-latest
-    defaults:
-      run:
-        shell: bash -el {0}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -358,15 +358,11 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - uses: gha3mi/setup-fortran-conda@v0.18.1
+      - name: Setup Fortran
+        uses: gha3mi/setup-fortran-conda@latest
         with:
           compiler: ifx
-
-      - name: Install compilers & dependencies with conda
-        run: |
-          conda install numpy
-#          conda install -c https://software.repos.intel.com/python/conda/ -c conda-forge ifx_win-64
-          conda install -c https://software.repos.intel.com/python/conda/ -c conda-forge mkl-static
+          extra-packages: "numpy mkl-static"
 
       # Set up the QT installer framework
       - uses: jmarrec/setup-qtifw@v1

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -353,7 +353,8 @@ jobs:
           $ncores = (Get-CimInstance -ClassName Win32_Processor | Measure-Object -Property NumberOfLogicalProcessors -Sum).Sum
           echo "num_cores=$ncores" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
-      - uses: actions/checkout@v6
+# Setup Fortran performs the checkout...
+#      - uses: actions/checkout@v6
 
       - name: Setup Fortran
         uses: gha3mi/setup-fortran-conda@latest

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -368,12 +368,12 @@ jobs:
 
       - name: Configure MOPAC with CMake
         run: |
-          cmake -B build \
-            -G Ninja \
-            -DBUILD_BZ=ON \
-            -DCMAKE_Fortran_COMPILER=ifx \
-            -DCMAKE_Fortran_FLAGS="/libs:static" \
-            -DBLA_STATIC=ON \
+          cmake -B build `
+            -G Ninja `
+            -DBUILD_BZ=ON `
+            -DCMAKE_Fortran_COMPILER=ifx `
+            -DCMAKE_Fortran_FLAGS="/libs:static" `
+            -DBLA_STATIC=ON `
             -DBLA_VENDOR=Intel10_64lp
 
       - name: Build MOPAC with Ninja

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -358,7 +358,7 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - uses: gha3mi/setup-fortran-conda@latest
+      - uses: gha3mi/setup-fortran-conda@v0.18.1
         with:
           compiler: ifx
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -372,7 +372,7 @@ jobs:
           cmake -B build `
             -G Ninja `
             -DBUILD_BZ=ON `
-            -DCMAKE_Fortran_COMPILER=ifx `
+            -DCMAKE_Fortran_COMPILER=gfortran `
             -DCMAKE_Fortran_FLAGS="/libs:static" `
             -DBLA_STATIC=ON `
             -DBLA_VENDOR=Intel10_64lp

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -362,23 +362,6 @@ jobs:
         with:
           compiler: ifx
 
-#      - name: Cache conda
-#        uses: actions/cache@v5
-#        env:
-#          # Increase this value to reset cache if etc/example-environment.yml has not changed
-#          CACHE_NUMBER: 0
-#        with:
-#          # Use faster GNU tar
-#          enableCrossOsArchive: true
-#          path: D:\conda_pkgs_dir
-#          key:
-#            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}
-#      - uses: conda-incubator/setup-miniconda@v4
-#        with:
-#          activate-environment: mopac
-#          channel-priority: strict
-#          pkgs-dirs: D:\conda_pkgs_dir
-
       - name: Install compilers & dependencies with conda
         run: |
           conda install numpy

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -344,6 +344,9 @@ jobs:
 
   windows-build:
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash -el {0}
     timeout-minutes: 30
 
     steps:
@@ -353,11 +356,24 @@ jobs:
           $ncores = (Get-CimInstance -ClassName Win32_Processor | Measure-Object -Property NumberOfLogicalProcessors -Sum).Sum
           echo "num_cores=$ncores" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
+      - name: Cache conda
+        uses: actions/cache@v5
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          # Use faster GNU tar
+          enableCrossOsArchive: true
+          path: D:\conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}
       - uses: conda-incubator/setup-miniconda@v4
         with:
           activate-environment: mopac
+          channel-priority: strict
+          pkgs-dirs: D:\conda_pkgs_dir
 
       - name: Install compilers & dependencies with conda
         run: |
@@ -371,27 +387,22 @@ jobs:
           qtifw-version: '4.6.x'
 
       - name: Configure MOPAC with CMake
-        shell: cmd
         run: |
-          echo %PATH%
-          cmake -Bbuild ^
-            -GNinja ^
-            -DBUILD_BZ=ON ^
-            -DCMAKE_Fortran_COMPILER=ifx ^
-            -DCMAKE_Fortran_FLAGS="/libs:static" ^
-            -DBLA_STATIC=ON ^
+          cmake -Bbuild \
+            -GNinja \
+            -DBUILD_BZ=ON \
+            -DCMAKE_Fortran_COMPILER=ifx \
+            -DCMAKE_Fortran_FLAGS="/libs:static" \
+            -DBLA_STATIC=ON \
             -DBLA_VENDOR=Intel10_64lp
 
       - name: Build MOPAC with Ninja
-        shell: cmd
-        run: |
-          cmake --build build -- -v
+        run: cmake --build build -- -v
 
       - name: Test MOPAC with CTest
-        shell: cmd
         run: |
           cd build
-          ctest -V -j %NUM_CORES%
+          ctest -V -j $NUM_CORES
 
       - name: Save test results as an artifact (on failure)
         if: ${{ failure() }}
@@ -401,20 +412,17 @@ jobs:
           path: build/tests
 
       - name: Local installation test
-        shell: cmd
         run: |
           cd build
           cmake --install .
 
       - name: Package MOPAC with CPack (in development)
-        shell: cmd
         run: |
           cd build
           cpack -G IFW
-          dir
+          ls
 
       - name: Local installation test & minimal packaging
-        shell: cmd
         run: |
           cd build
           make install

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,10 +18,6 @@ env:
   MKL_LINUX_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/adb8a02c-4ee7-4882-97d6-a524150da358/l_onemkl_p_2023.2.0.49497_offline.sh
   IFORT_MAC_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
   MKL_MAC_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/9399bece-76fb-4b1c-b15c-8ac295448513/m_onemkl_p_2023.2.0.49501_offline.dmg
-  IFORT_WINDOWS_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/1720594b-b12c-4aca-b7fb-a7d317bac5cb/w_fortran-compiler_p_2023.2.1.7_offline.exe
-  MKL_WINDOWS_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2b9cdf66-5291-418e-a7e8-f90515cc9098/w_onemkl_p_2023.2.0.49500_offline.exe
-  IFORT_WINDOWS_VERSION: 2023.2.1
-  MKL_WINDOWS_VERSION: 2023.2.0
 
 jobs:
   linux-static:
@@ -359,47 +355,29 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: conda-incubator/setup-miniconda@v4
         with:
-          python-version: '3.x'
+          activate-environment: mopac
+
+      - name: Install compilers & dependencies with conda
+        run: |
+          conda install numpy
+          conda install -c https://software.repos.intel.com/python/conda/ -c conda-forge ifx_win-64
+          conda install -c https://software.repos.intel.com/python/conda/ -c conda-forge mkl-static
 
       # Set up the QT installer framework
       - uses: jmarrec/setup-qtifw@v1
         with:
           qtifw-version: '4.6.x'
 
-      - name: Cache Intel Fortran compiler
-        id: cache-intel
-        uses: actions/cache@v4
-        with:
-          path: C:\Program Files (x86)\Intel
-          key: cache-${{ env.IFORT_WINDOWS_URL }}-${{ env.MKL_WINDOWS_URL }}
-
-      - name: Download & install Intel Fortran compiler
-        if: steps.cache-intel.outputs.cache-hit != 'true'
-        shell: cmd
-        run: |
-          curl ${{ env.IFORT_WINDOWS_URL }} --output ifort_download.exe
-          ifort_download -s -x -f ifort_unpack
-          ifort_unpack\bootstrapper --silent --eula accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0
-          curl ${{ env.MKL_WINDOWS_URL }} --output mkl_download.exe
-          mkl_download -s -x -f mkl_unpack
-          mkl_unpack\bootstrapper --silent --eula accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0
-
-      - name: Install dependencies with PyPI
-        run: pip3 install numpy
-
-      # The main Intel\oneAPI\setvars.bat script is not setting up the correct version of ifort, so using component-level scripts
       - name: Configure MOPAC with CMake
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Intel\oneAPI\compiler\${{ env.IFORT_WINDOWS_VERSION }}\env\vars.bat"
-          call "C:\Program Files (x86)\Intel\oneAPI\mkl\${{ env.MKL_WINDOWS_VERSION }}\env\vars.bat"
           echo %PATH%
           cmake -Bbuild ^
             -GNinja ^
             -DBUILD_BZ=ON ^
-            -DCMAKE_Fortran_COMPILER=ifort ^
+            -DCMAKE_Fortran_COMPILER=ifx ^
             -DCMAKE_Fortran_FLAGS="/libs:static" ^
             -DBLA_STATIC=ON ^
             -DBLA_VENDOR=Intel10_64lp
@@ -407,15 +385,11 @@ jobs:
       - name: Build MOPAC with Ninja
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Intel\oneAPI\compiler\${{ env.IFORT_WINDOWS_VERSION }}\env\vars.bat"
-          call "C:\Program Files (x86)\Intel\oneAPI\mkl\${{ env.MKL_WINDOWS_VERSION }}\env\vars.bat"
           cmake --build build -- -v
 
       - name: Test MOPAC with CTest
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Intel\oneAPI\compiler\${{ env.IFORT_WINDOWS_VERSION }}\env\vars.bat"
-          call "C:\Program Files (x86)\Intel\oneAPI\mkl\${{ env.MKL_WINDOWS_VERSION }}\env\vars.bat"
           cd build
           ctest -V -j %NUM_CORES%
 
@@ -435,8 +409,6 @@ jobs:
       - name: Package MOPAC with CPack (in development)
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Intel\oneAPI\compiler\${{ env.IFORT_WINDOWS_VERSION }}\env\vars.bat"
-          call "C:\Program Files (x86)\Intel\oneAPI\mkl\${{ env.MKL_WINDOWS_VERSION }}\env\vars.bat"
           cd build
           cpack -G IFW
           dir
@@ -444,8 +416,6 @@ jobs:
       - name: Local installation test & minimal packaging
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Intel\oneAPI\compiler\${{ env.IFORT_WINDOWS_VERSION }}\env\vars.bat"
-          call "C:\Program Files (x86)\Intel\oneAPI\mkl\${{ env.MKL_WINDOWS_VERSION }}\env\vars.bat"
           cd build
           make install
           cpack -G ZIP

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -358,27 +358,31 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: Cache conda
-        uses: actions/cache@v5
-        env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
-          CACHE_NUMBER: 0
+      - uses: gha3mi/setup-fortran-conda@latest
         with:
-          # Use faster GNU tar
-          enableCrossOsArchive: true
-          path: D:\conda_pkgs_dir
-          key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}
-      - uses: conda-incubator/setup-miniconda@v4
-        with:
-          activate-environment: mopac
-          channel-priority: strict
-          pkgs-dirs: D:\conda_pkgs_dir
+          compiler: ifx
+
+#      - name: Cache conda
+#        uses: actions/cache@v5
+#        env:
+#          # Increase this value to reset cache if etc/example-environment.yml has not changed
+#          CACHE_NUMBER: 0
+#        with:
+#          # Use faster GNU tar
+#          enableCrossOsArchive: true
+#          path: D:\conda_pkgs_dir
+#          key:
+#            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}
+#      - uses: conda-incubator/setup-miniconda@v4
+#        with:
+#          activate-environment: mopac
+#          channel-priority: strict
+#          pkgs-dirs: D:\conda_pkgs_dir
 
       - name: Install compilers & dependencies with conda
         run: |
           conda install numpy
-          conda install -c https://software.repos.intel.com/python/conda/ -c conda-forge ifx_win-64
+#          conda install -c https://software.repos.intel.com/python/conda/ -c conda-forge ifx_win-64
           conda install -c https://software.repos.intel.com/python/conda/ -c conda-forge mkl-static
 
       # Set up the QT installer framework

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -359,7 +359,7 @@ jobs:
       - name: Setup Fortran
         uses: gha3mi/setup-fortran-conda@latest
         with:
-          compiler: ifx
+          compiler: gfortran
           extra-packages: "numpy mkl-static"
 
       # Set up the QT installer framework

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -368,8 +368,8 @@ jobs:
 
       - name: Configure MOPAC with CMake
         run: |
-          cmake -Bbuild \
-            -GNinja \
+          cmake -B build \
+            -G Ninja \
             -DBUILD_BZ=ON \
             -DCMAKE_Fortran_COMPILER=ifx \
             -DCMAKE_Fortran_FLAGS="/libs:static" \


### PR DESCRIPTION
<!-- Describe your PR -->
The Windows GHA build script failed about a month ago because the Visual Studio version is now beyond the compatibility range of the now-obsolete ifort compiler, which will no longer install correctly from the standalone installer. This PR switches to the ifx compiler and its Conda-forge distribution for Windows. I will overhaul the GHA build script more extensively when I switch primary Mac distribution from x86 to ARM, which will likely happen in 2027 before Intel-based Github Actions Mac runners are no longer available.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [ ] Ready for merge
