### PR TITLE
Downgrade GHA Windows runner image from 2025 to 2022

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -347,7 +347,7 @@ jobs:
           path: build/mopac-*-mac.*
 
   windows-build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
<!-- Describe your PR -->
This is meant as a temporary CI fix to resolve #320. This fix will only last until the Windows 2022 server image is decommissioned. A more permanent fix will be to improve the CMake build system and Github Actions build script, hopefully reducing the number of environment-specific hacks that are needed for everything to work.

## Status
<!-- Put an 'x' in the checkbox if your PR is ready to be merged into the main MOPAC branch -->
- [ ] Ready for merge
